### PR TITLE
Disambiguate with mutability

### DIFF
--- a/SConscript.inference
+++ b/SConscript.inference
@@ -18,7 +18,7 @@ def which(executable):
 
 # the following must be exported by parent SConstruct/SConscript
 Import(
-    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile"
+    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability"
 )
 
 
@@ -209,6 +209,8 @@ if bootstrap:
 gctree_outbase = os.path.join(outdir, "gctree")
 frame_arg = " --frame {} ".format(frame) if frame is not None else ""
 idlabel_arg = " --idlabel" if idlabel else ""
+mutabilitymodel = " --mutability {}".format(mutability) if mutability else ""
+substitutionmodel = " --substitution {}".format(substitution) if substitution else ""
 gctree_infer = CommandRunner(
     [
         gctree_outbase + ".inference.parsimony_forest.p",
@@ -227,6 +229,9 @@ gctree_infer = CommandRunner(
     + idlabel_arg
     + (" --colormap ${SOURCES[-1]} " if colorfile is not None else "")
     + (" --bootstrap_phylipfile ${SOURCES[2]}" if bootstrap else "")
+    + (" --disambiguate_with_mutability" if disambiguate_with_mutability else "")
+    + mutabilitymodel
+    + substitutionmodel
     + " | tee ${TARGETS[1]}",
 )
 return_list.append(gctree_infer)

--- a/SConstruct
+++ b/SConstruct
@@ -61,6 +61,28 @@ AddOption(
     action="store_true",
     help="use stdbuf to prevent line buffering on linux",
 )
+AddOption(
+    "--disambiguate_with_mutability",
+    action="store_true",
+    help="use mutability model provided using ``mutability'' and ``substitution'' arguments to attempt to optimally resolve ambiguities in dnapars output trees"
+)
+disambiguate_with_mutability = GetOption("disambiguate_with_mutability")
+AddOption(
+    "--mutability",
+    type="string",
+    metavar="PATH",
+    default="S5F/Mutability.csv",
+    help="path to S5F mutability data",
+)
+mutability = GetOption("mutability")
+AddOption(
+    "--substitution",
+    type="string",
+    metavar="PATH",
+    default="S5F/Substitution.csv",
+    help="path to S5F substitution data",
+)
+substitution = GetOption("substitution")
 buffarg = "stdbuf -oL " if GetOption("nobuff") else ""
 
 
@@ -86,22 +108,6 @@ if simulate:
         help="sequence of root from which to simulate",
     )
     root = GetOption("root")
-    AddOption(
-        "--mutability",
-        type="string",
-        metavar="PATH",
-        default="S5F/Mutability.csv",
-        help="path to S5F mutability data",
-    )
-    mutability = GetOption("mutability")
-    AddOption(
-        "--substitution",
-        type="string",
-        metavar="PATH",
-        default="S5F/Substitution.csv",
-        help="path to S5F substitution data",
-    )
-    substitution = GetOption("substitution")
     AddOption(
         "--lambda",
         type="float",
@@ -217,5 +223,5 @@ elif inference and not GetOption("help"):
         raise InputError("input fasta or phylip and outdir must be specified")
     SConscript(
         "SConscript.inference",
-        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile",
+        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability",
     )

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -156,10 +156,33 @@ def test(args):
 
 def infer(args):
     """inference subprogram."""
-    outfiles = [pp.parse_outfile(args.phylipfile, args.abundance_file, args.root)]
+    if args.disambiguate_with_mutability:
+        model = mm.MutationModel(
+            mutability_file=args.mutability, substitution_file=args.substitution
+        )
+        dist_func = utils.mutability_distance(model)
+        dependence_window = 2
+    else:
+        dist_func = utils.hamming_distance
+        dependence_window = 0
+    outfiles = [
+        pp.parse_outfile(
+            args.phylipfile,
+            args.abundance_file,
+            args.root,
+            dist_func=dist_func,
+            dependence_window=dependence_window,
+        )
+    ]
     if args.bootstrap_phylipfile is not None:
         outfiles.extend(
-            pp.parse_outfile(args.bootstrap_phylipfile, args.abundance_file, args.root)
+            pp.parse_outfile(
+                args.bootstrap_phylipfile,
+                args.abundance_file,
+                args.root,
+                dist_func=dist_func,
+                dependence_window=dependence_window,
+            )
         )
     bootstrap = len(outfiles) > 1
     if bootstrap:
@@ -645,6 +668,23 @@ def get_parser():
         type=str,
         default=None,
         help="positionmapfile for the 2nd chain when using the ``chain_split`` option",
+    )
+    parser_infer.add_argument(
+        "--disambiguate_with_mutability",
+        action="store_true",
+        help="use mutability model provided using ``mutability'' and ``substitution'' arguments to attempt to optimally resolve ambiguities in dnapars output trees",
+    )
+    parser_infer.add_argument(
+        "--mutability",
+        type=str,
+        default=None,
+        help="path to mutability model file to be used with option ``disambiguate_with_mutability''",
+    )
+    parser_infer.add_argument(
+        "--substitution",
+        type=str,
+        default=None,
+        help="path to substitution model file to be used with option ``disambiguate_with_mutability''",
     )
     parser_infer.set_defaults(func=infer)
 

--- a/gctree/mutation_model.py
+++ b/gctree/mutation_model.py
@@ -59,7 +59,6 @@ class MutationModel:
         else:
             self.context_model = None
 
-
     def mutability(self, kmer: str) -> Tuple[np.float64, np.float64]:
         r"""Returns the mutability of a central base of :math:`k`-mer, along with
         nucleotide bias averages over ambiguous ``"N"`` nucleotide identities.

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -129,14 +129,14 @@ def parse_outfile(outfile, abundance_file=None, root="root", **kwargs):
 
 
 def disambiguate(
-    tree: Tree, random_state=None, dist_func=hamming_distance, distance_dependence=0
+    tree: Tree, random_state=None, dist_func=hamming_distance, dependence_window=0
 ) -> Tree:
     """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
     subtrees of consecutive ambiguity codes.
     If passing a nonstandard distance function, the user must specify how many bases on either side of a focused base must be considered.
-    Distance_dependence is max distance a motif extends past focused
-    base, so a centered motif of length 5 has distance_dependence 2.
-    If the entire sequence should be disambiguated at once, use distance_dependence -1.
+    dependence_window is max distance a motif extends past focused
+    base, so a centered motif of length 5 has dependence_window 2.
+    If the entire sequence should be disambiguated at once, use dependence_window -1.
     """
 
     def is_ambiguous(sequence):
@@ -147,11 +147,11 @@ def disambiguate(
     else:
         random.setstate(random_state)
 
-    if distance_dependence == -1:
+    if dependence_window == -1:
         windows_to_disambiguate = [(0, len(tree.sequence))]
     else:
         # smash all sequences in tree into one, find windows containing
-        # ambiguities, padded by at least distance_dependence unambiguous bases
+        # ambiguities, padded by at least dependence_window unambiguous bases
         sequencelist = [node.sequence for node in tree.traverse()]
         is_ambiguous_collapsed = [
             any((sequence[index] not in bases for sequence in sequencelist))
@@ -162,13 +162,13 @@ def disambiguate(
         ]
 
         def is_window_beginning(ambig_index):
-            before_index = max([0, ambig_index - distance_dependence])
+            before_index = max([0, ambig_index - dependence_window])
             return not any(is_ambiguous_collapsed[before_index:ambig_index])
 
         def is_window_end(ambig_index):
             return not any(
                 is_ambiguous_collapsed[
-                    ambig_index + 1 : ambig_index + distance_dependence + 1
+                    ambig_index + 1 : ambig_index + dependence_window + 1
                 ]
             )
 
@@ -178,7 +178,7 @@ def disambiguate(
         window_ends = (index for index in ambiguous_indices if is_window_end(index))
         # tuples of starting and stopping indices which contain ambiguities in any of the sequences in sequencelist, including non-ambiguous padding around the ambiguities.
         windows_to_disambiguate = [
-            (max([0, a - distance_dependence]), b + distance_dependence + 1)
+            (max([0, a - dependence_window]), b + dependence_window + 1)
             for a, b in zip(window_beginnings, window_ends)
         ]
     for node in tree.traverse():

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -249,7 +249,13 @@ def disambiguate(
 
 # build a tree from a set of sequences and an adjacency dict.
 def build_tree(
-    sequences, parents, counts=None, root="root", dist_func=hamming_distance, disambiguate=True, **kwargs
+    sequences,
+    parents,
+    counts=None,
+    root="root",
+    dist_func=hamming_distance,
+    disambiguate=True,
+    **kwargs
 ):
     # build an ete tree
     # first a dictionary of disconnected nodes

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -228,7 +228,7 @@ def disambiguate(
                             for child in node2.children:
                                 seq_cost[1] += min(
                                     [
-                                        dist_func(child_seq, seq_cost[0])
+                                        dist_func(seq_cost[0], child_seq)
                                         + child_cost
                                         for child_seq, child_cost in child.costs
                                     ]
@@ -306,7 +306,7 @@ def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_d
         if len(root_parent.children) == 1:
             root_parent.delete(prevent_nondicotomic=False)
             root_parent.children[0].dist = dist_func(
-                root_parent.children[0].sequence, nodes[root_id].sequence
+                nodes[root_id].sequence, root_parent.children[0].sequence
             )
         tree = nodes[root_id]
 
@@ -316,7 +316,7 @@ def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_d
     # compute branch lengths
     tree.dist = 0  # no branch above root
     for node in tree.iter_descendants():
-        node.dist = dist_func(node.sequence, node.up.sequence)
+        node.dist = dist_func(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -126,7 +126,9 @@ def parse_outfile(outfile, abundance_file=None, root="root", **kwargs):
                         )
                     )
                 if bootstrap:
-                    trees[-1].append(build_tree(sequences, parents, counts, root, **kwargs ))
+                    trees[-1].append(
+                        build_tree(sequences, parents, counts, root, **kwargs)
+                    )
                 else:
                     trees.append(build_tree(sequences, parents, counts, root, **kwargs))
             elif sect == "seqboot_dataset":
@@ -228,8 +230,7 @@ def disambiguate(
                             for child in node2.children:
                                 seq_cost[1] += min(
                                     [
-                                        dist_func(seq_cost[0], child_seq)
-                                        + child_cost
+                                        dist_func(seq_cost[0], child_seq) + child_cost
                                         for child_seq, child_cost in child.costs
                                     ]
                                 )
@@ -276,7 +277,9 @@ def disambiguate(
 
 
 # build a tree from a set of sequences and an adjacency dict.
-def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs):
+def build_tree(
+    sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs
+):
     # build an ete tree
     # first a dictionary of disconnected nodes
     nodes = {}

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -249,7 +249,7 @@ def disambiguate(
 
 # build a tree from a set of sequences and an adjacency dict.
 def build_tree(
-    sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs
+    sequences, parents, counts=None, root="root", dist_func=hamming_distance, disambiguate=True, **kwargs
 ):
     # build an ete tree
     # first a dictionary of disconnected nodes
@@ -284,13 +284,14 @@ def build_tree(
             )
         tree = nodes[root_id]
 
-    # make random choices for ambiguous bases
-    tree = disambiguate(tree, dist_func=dist_func, **kwargs)
+    if disambiguate:
+        # make random choices for ambiguous bases
+        tree = disambiguate(tree, dist_func=dist_func, **kwargs)
 
-    # compute branch lengths
-    tree.dist = 0  # no branch above root
-    for node in tree.iter_descendants():
-        node.dist = dist_func(node.up.sequence, node.sequence)
+        # compute branch lengths
+        tree.dist = 0  # no branch above root
+        for node in tree.iter_descendants():
+            node.dist = dist_func(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -254,7 +254,7 @@ def build_tree(
     counts=None,
     root="root",
     dist_func=hamming_distance,
-    disambiguate=True,
+    resolve_ambiguities=True,
     **kwargs
 ):
     # build an ete tree
@@ -285,19 +285,22 @@ def build_tree(
         # remove possible unecessary unifurcation after rerooting
         if len(root_parent.children) == 1:
             root_parent.delete(prevent_nondicotomic=False)
-            root_parent.children[0].dist = dist_func(
+            # this must stay hamming_distance, not dist_func
+            # used for collapsing logic.
+            root_parent.children[0].dist = hamming_distance(
                 nodes[root_id].sequence, root_parent.children[0].sequence
             )
         tree = nodes[root_id]
 
-    if disambiguate:
+    if resolve_ambiguities:
         # make random choices for ambiguous bases
         tree = disambiguate(tree, dist_func=dist_func, **kwargs)
 
         # compute branch lengths
         tree.dist = 0  # no branch above root
         for node in tree.iter_descendants():
-            node.dist = dist_func(node.up.sequence, node.sequence)
+            # This must stay hamming_distance, not dist_func
+            node.dist = hamming_distance(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,8 +1,9 @@
+from math import log
+
 r"""Utility functions."""
 
 
 def check_distance_arguments(distance):
-
     def new_distance(seq1: str, seq2: str, *args, **kwargs):
         if len(seq1) != len(seq2):
             raise ValueError(
@@ -11,6 +12,7 @@ def check_distance_arguments(distance):
         return distance(seq1, seq2, *args, **kwargs)
 
     return new_distance
+
 
 @check_distance_arguments
 def hamming_distance(seq1: str, seq2: str) -> int:
@@ -22,15 +24,22 @@ def hamming_distance(seq1: str, seq2: str) -> int:
     """
     return sum(x != y for x, y in zip(seq1, seq2))
 
+
 @check_distance_arguments
 def mutability_distance(seq1: str, seq2: str, mutability_model) -> float:
-    """Assume that sequences being compared are already padded, so this will be a sum of
-    negative log biases over bases within the padding margin...but that will be a problem
-    when there's an ambiguity at the beginning of the sequence"""
+    """Assume that sequences being compared are already padded, so this will be
+    a sum of negative log biases over bases within the padding margin...but
+    that will be a problem when there's an ambiguity at the beginning of the
+    sequence."""
     mutabilities = mutability_model.mutabilities(seq1)
     normalizing_constant = sum(mut for mut, _ in mutabilities)
-    normalized_mutabilities = [(mut / normalizing_constant, biases) for mut, biases in mutabilities]
-    transition_costs = [-log(mut[0] * mut[1][seq2[index]]) if seq1[index] == seq2[index]
-                        else -log(1-mut[0])
-                        for index, mutability in enumerate(mutabilities)]
+    normalized_mutabilities = [
+        (mut / normalizing_constant, biases) for mut, biases in mutabilities
+    ]
+    transition_costs = [
+        -log(mut[0] * mut[1][seq2[index]])
+        if seq1[index] == seq2[index]
+        else -log(1 - mut[0])
+        for index, mut in enumerate(normalized_mutabilities)
+    ]
     return sum(transition_costs)

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -86,6 +86,10 @@ def mutability_distance(mutation_model):
         a sum of negative log biases over bases within the padding margin...but
         that will be a problem when there's an ambiguity at the beginning of the
         sequence."""
+        if len(seq1) < 2:
+            raise ValueError(
+                "mutability distance function can only compare sequences of more than one base"
+            )
         muts = mutabilities(seq1)
         nc = sum(mut for mut, _ in muts)
         return sum(

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -6,6 +6,7 @@ r"""Utility functions."""
 bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
 
+
 def disambiguations(sequence, accum=""):
     """Iterates through possible disambiguations of sequence, recursively.
     Recursion-depth-limited by number of ambiguity codes in
@@ -22,6 +23,7 @@ def disambiguations(sequence, accum=""):
                     )
                 return
     yield accum
+
 
 def check_distance_arguments(distance):
     def new_distance(seq1: str, seq2: str, *args, **kwargs):
@@ -55,10 +57,12 @@ def mutability_distance(mutation_model):
     k = mutation_model.k
     h = k // 2
     # Build all sequences with (when k=5) one or two Ns on either end
-    templates = [("N"* left, "N" * (k - left - right), "N" * right)
-                 for left in range(h + 1)
-                 for right in range(h + 1)
-                 if left != 0 or right != 0]
+    templates = [
+        ("N" * left, "N" * (k - left - right), "N" * right)
+        for left in range(h + 1)
+        for right in range(h + 1)
+        if left != 0 or right != 0
+    ]
 
     kmers_to_compute = [
         leftns + stub + rightns
@@ -66,7 +70,9 @@ def mutability_distance(mutation_model):
         for stub in disambiguations(ambig_stub)
     ]
     # Cache all these mutabilities in context_model also
-    context_model.update({kmer: mutation_model.mutability(kmer) for kmer in kmers_to_compute})
+    context_model.update(
+        {kmer: mutation_model.mutability(kmer) for kmer in kmers_to_compute}
+    )
 
     def mutabilities(seq):
         newseq = "N" * h + seq + "N" * h

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,6 +1,18 @@
 r"""Utility functions."""
 
 
+def check_distance_arguments(distance):
+
+    def new_distance(seq1: str, seq2: str, *args, **kwargs):
+        if len(seq1) != len(seq2):
+            raise ValueError(
+                f"sequences must have equal length, got {len(seq1)} and {len(seq2)}"
+            )
+        return distance(seq1, seq2, *args, **kwargs)
+
+    return new_distance
+
+@check_distance_arguments
 def hamming_distance(seq1: str, seq2: str) -> int:
     r"""Hamming distance between two sequences of equal length.
 
@@ -8,10 +20,17 @@ def hamming_distance(seq1: str, seq2: str) -> int:
         seq1: sequence 1
         seq2: sequence 2
     """
-
-    if len(seq1) != len(seq2):
-        raise ValueError(
-            f"sequences must have equal length, got {len(seq1)} and {len(seq2)}"
-        )
-
     return sum(x != y for x, y in zip(seq1, seq2))
+
+@check_distance_arguments
+def mutability_distance(seq1: str, seq2: str, mutability_model) -> float:
+    """Assume that sequences being compared are already padded, so this will be a sum of
+    negative log biases over bases within the padding margin...but that will be a problem
+    when there's an ambiguity at the beginning of the sequence"""
+    mutabilities = mutability_model.mutabilities(seq1)
+    normalizing_constant = sum(mut for mut, _ in mutabilities)
+    normalized_mutabilities = [(mut / normalizing_constant, biases) for mut, biases in mutabilities]
+    transition_costs = [-log(mut[0] * mut[1][seq2[index]]) if seq1[index] == seq2[index]
+                        else -log(1-mut[0])
+                        for index, mutability in enumerate(mutabilities)]
+    return sum(transition_costs)

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -7,7 +7,7 @@ bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
 
 
-def disambiguations(sequence, accum=""):
+def disambiguations(sequence, _accum=""):
     """Iterates through possible disambiguations of sequence, recursively.
     Recursion-depth-limited by number of ambiguity codes in
     sequence, not sequence length.
@@ -15,14 +15,14 @@ def disambiguations(sequence, accum=""):
     if sequence:
         for index, base in enumerate(sequence):
             if base in bases:
-                accum += base
+                _accum += base
             else:
                 for newbase in ambiguous_dna_values[base]:
                     yield from disambiguations(
-                        sequence[index + 1 :], accum=(accum + newbase)
+                        sequence[index + 1 :], _accum=(_accum + newbase)
                     )
                 return
-    yield accum
+    yield _accum
 
 
 def check_distance_arguments(distance):

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -76,7 +76,8 @@ def test_restricted_ambiguity():
         print(f"\nDisambiguate function is missing {missing}\n"
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
-    
+
+
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=3)
     correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -108,3 +108,37 @@ def test_restricted_ambiguity_widewindow():
         print(f"\nDisambiguate function is missing {missing}\n"
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
+
+def test_sequence_disambiguate():
+    sequences = ["GVNT", "?TCM"]
+    lsts = [list(utils.disambiguations(sequence)) for sequence in sequences]
+    correctsets = [
+        {"GAAT",
+         "GACT",
+         "GAGT",
+         "GATT",
+         "GCAT",
+         "GCCT",
+         "GCGT",
+         "GCTT",
+         "GGAT",
+         "GGCT",
+         "GGGT",
+         "GGTT"},
+        {"ATCA",
+         "ATCC",
+         "GTCA",
+         "GTCC",
+         "CTCA",
+         "CTCC",
+         "TTCA",
+         "TTCC",
+         "-TCA",
+         "-TCC"}
+    ]
+    for seq, lst, correctset in zip(sequences, lsts, correctsets):
+        if not len(lst) == len(set(lst)):
+            raise ValueError("Non-unique sequence disambiguation")
+        if not set(lst) == correctset:
+            raise ValueError(f"Incorrect disambiguation of sequence {seq}:\n{lst}")
+

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -1,3 +1,4 @@
+from gctree import mutation_model, utils
 import random
 import ete3
 import gctree.phylip_parse as pps
@@ -35,13 +36,14 @@ def treeprint(tree: ete3.TreeNode):
     return(tree.write(format=8))
 
 
-def sample(tree, n=20, distance_dependence=0):
+def sample(tree, n=20, **kwargs):
     print(tree.sequence)
     newickset = set()
     for i in range(n):
         t = tree.copy()
         random.seed(i)
-        t = pps.disambiguate(t, random_state=random.getstate(), distance_dependence=distance_dependence)
+        t = pps.disambiguate(t, random_state=random.getstate(), **kwargs)
+        print(treeprint(t))
         newickset.add(treeprint(t))
     return(newickset)
 
@@ -77,6 +79,17 @@ def test_restricted_ambiguity():
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
 
+
+def test_restricted_ambiguity_widewindow_mutability():
+    mmodel = mutation_model.MutationModel(mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv")
+    newickset = sample(tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2)
+    correctset = {'((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);'}
+    if not newickset == correctset:
+        missing = correctset - newickset
+        wrong = newickset - correctset
+        print(f"\nDisambiguate function is missing {missing}\n"
+              f"and came up with these incorrect trees: {wrong}")
+        raise ValueError("Invalid Disambiguation")
 
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=3)

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -3,21 +3,25 @@ import random
 import ete3
 import gctree.phylip_parse as pps
 
-newick_tree1 = ("((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
-                "(6[&&NHX:name=6:sequence=C],"
-                "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=M])"
-                "3[&&NHX:name=3:sequence=M],8[&&NHX:name=8:sequence=A],"
-                "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
-                "9[&&NHX:name=9:sequence=R])2[&&NHX:name=2:sequence=R])"
-                "1[&&NHX:name=1:sequence=G];")
+newick_tree1 = (
+    "((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
+    "(6[&&NHX:name=6:sequence=C],"
+    "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=M])"
+    "3[&&NHX:name=3:sequence=M],8[&&NHX:name=8:sequence=A],"
+    "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
+    "9[&&NHX:name=9:sequence=R])2[&&NHX:name=2:sequence=R])"
+    "1[&&NHX:name=1:sequence=G];"
+)
 
-newick_tree2 = ("((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
-                "(6[&&NHX:name=6:sequence=C],"
-                "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=?])"
-                "3[&&NHX:name=3:sequence=?],8[&&NHX:name=8:sequence=A],"
-                "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
-                "9[&&NHX:name=9:sequence=?])2[&&NHX:name=2:sequence=?])"
-                "1[&&NHX:name=1:sequence=G];")
+newick_tree2 = (
+    "((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
+    "(6[&&NHX:name=6:sequence=C],"
+    "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=?])"
+    "3[&&NHX:name=3:sequence=?],8[&&NHX:name=8:sequence=A],"
+    "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
+    "9[&&NHX:name=9:sequence=?])2[&&NHX:name=2:sequence=?])"
+    "1[&&NHX:name=1:sequence=G];"
+)
 
 tree1 = ete3.TreeNode(newick=newick_tree1, format=1)
 for node in tree1.traverse():
@@ -33,7 +37,7 @@ def treeprint(tree: ete3.TreeNode):
     tree = tree.copy()
     for node in tree.traverse():
         node.name = node.sequence
-    return(tree.write(format=8))
+    return tree.write(format=8)
 
 
 def sample(tree, n=20, **kwargs):
@@ -45,100 +49,123 @@ def sample(tree, n=20, **kwargs):
         t = pps.disambiguate(t, random_state=random.getstate(), **kwargs)
         print(treeprint(t))
         newickset.add(treeprint(t))
-    return(newickset)
+    return newickset
 
 
 def test_full_ambiguity():
     newickset = sample(tree2)
-    correctset = {"((((T)C,(C,A)C)C,A,(A,G)G)G);",
-                  "((((T)C,(C,A)A)A,A,(A,G)A)A);",
-                  "((((T)C,(C,A)C)C,A,(A,G)A)A);"}
+    correctset = {
+        "((((T)C,(C,A)C)C,A,(A,G)G)G);",
+        "((((T)C,(C,A)A)A,A,(A,G)A)A);",
+        "((((T)C,(C,A)C)C,A,(A,G)A)A);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
 
 
 def test_restricted_ambiguity():
     newickset = sample(tree1)
-    correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);'}
+    correctset = {
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
 
 
 def test_restricted_ambiguity_widewindow_mutability():
-    mmodel = mutation_model.MutationModel(mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv")
-    newickset = sample(tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2)
-    correctset = {'((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);'}
+    mmodel = mutation_model.MutationModel(
+        mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv"
+    )
+    newickset = sample(
+        tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2
+    )
+    correctset = {"((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);"}
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
+
 
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=-1)
-    correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);'}
+    correctset = {
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
+
 
 def test_sequence_disambiguate():
     sequences = ["GVNT", "?TCM"]
     lsts = [list(utils.disambiguations(sequence)) for sequence in sequences]
     correctsets = [
-        {"GAAT",
-         "GACT",
-         "GAGT",
-         "GATT",
-         "GCAT",
-         "GCCT",
-         "GCGT",
-         "GCTT",
-         "GGAT",
-         "GGCT",
-         "GGGT",
-         "GGTT"},
-        {"ATCA",
-         "ATCC",
-         "GTCA",
-         "GTCC",
-         "CTCA",
-         "CTCC",
-         "TTCA",
-         "TTCC",
-         "-TCA",
-         "-TCC"}
+        {
+            "GAAT",
+            "GACT",
+            "GAGT",
+            "GATT",
+            "GCAT",
+            "GCCT",
+            "GCGT",
+            "GCTT",
+            "GGAT",
+            "GGCT",
+            "GGGT",
+            "GGTT",
+        },
+        {
+            "ATCA",
+            "ATCC",
+            "GTCA",
+            "GTCC",
+            "CTCA",
+            "CTCC",
+            "TTCA",
+            "TTCC",
+            "-TCA",
+            "-TCC",
+        },
     ]
     for seq, lst, correctset in zip(sequences, lsts, correctsets):
         if not len(lst) == len(set(lst)):
             raise ValueError("Non-unique sequence disambiguation")
         if not set(lst) == correctset:
             raise ValueError(f"Incorrect disambiguation of sequence {seq}:\n{lst}")
-

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -92,7 +92,7 @@ def test_restricted_ambiguity_widewindow_mutability():
         raise ValueError("Invalid Disambiguation")
 
 def test_restricted_ambiguity_widewindow():
-    newickset = sample(tree1, n=100, distance_dependence=3)
+    newickset = sample(tree1, n=100, distance_dependence=-1)
     correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
                   '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
                   '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -97,7 +97,7 @@ def test_restricted_ambiguity_widewindow_mutability():
         mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv"
     )
     newickset = sample(
-        tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2
+        tree1, n=5, dist_func=utils.mutability_distance(mmodel), dependence_window=2
     )
     correctset = {"((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);"}
     if not newickset == correctset:
@@ -111,7 +111,7 @@ def test_restricted_ambiguity_widewindow_mutability():
 
 
 def test_restricted_ambiguity_widewindow():
-    newickset = sample(tree1, n=100, distance_dependence=-1)
+    newickset = sample(tree1, n=100, dependence_window=-1)
     correctset = {
         "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
         "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",


### PR DESCRIPTION
# Goal:
Make it possible to choose a disambiguation of ambiguity codes in trees output by dnapars that optimizes a distance function other than Hamming distance

# Description of Changes
* Redesign (again) the `phylip_parse.disambiguate` function. The basic method is still the same as implemented in #57, but it was necessary to accommodate distance functions (like one based on a 5-mer mutability model) that aren't site-wise independent. The user now may pass a function and an integer `dependence_window` to the disambiguate function, and each tree's sequences will be disambiguated in chunks, so that each chunk pads any ambiguities with at least `dependence_window` unambiguous bases. If `dependence_window` is -1, the entire sequence at each node will be disambiguated at once.
    * Note that this solution does not guarantee that a tree with ambiguity codes (such as one output by dnapars), when disambiguated according to a distance function other than hamming distance, will actually end up being a maximum parsimony tree. Some combinations of resolutions of ambiguity codes in a tree are not optimal. Choosing optimal combinations requires the Sankoff algorithm.
    * The 'distance' function passed to the disambiguate function need not be a real distance. In particular, it need not be positive definite or symmetric on its arguments. However, it should probably obey:
        * additivity over bases (although not necessarily site-wise independence)
        * lower distance indicates 'better' agreement between input sequences
* Added the function `utils.mutability_distance`, which takes a `mutation_model.MutationModel` object and returns a distance function. This is a draft, I'm not sure if I'm using the mutability and base biases correctly in this function.
    * In order to speed up computations, mutability_distance computes and caches mutabilities of k-mers with any number of consecutive `N`'s on either end (as long as the central base is always unambiguous). This caching could be moved to `MutationModel.__init__` if this caching would be useful somewhere else. For disambiguations, it's essential.
* Added the function `utils.disambiguations`, which takes a sequence including any ambiguity codes, and returns a generator on disambiguations of that sequence. This function is now used by `phylip_parse.disambiguate` and `mutation_model.MutationModel.mutability`.
* Removed the `MutationModel._disambiguate` static method (the disambiguations function in utils is faster and equivalent)
* Add options `--disambiguate_with_mutability`, `--mutability`, and `--substitution` to the Scons inference pipeline, as well as to the gctree inference cli.

# Tests
* Added tests for `phylip_parse.disambiguate` and `utils.disambiguations`.
* Run on sample data, the method does find lower weight trees according to the mutability model in the `S5F` directory.

## Yet to do
* Is the mutability_distance function reasonable?
* Make the option to disambiguate using a different function accessible to a user of the Scons pipeline?