### PR TITLE
Use history DAG to find more maximum parsimony trees

### DIFF
--- a/SConscript.inference
+++ b/SConscript.inference
@@ -18,7 +18,7 @@ def which(executable):
 
 # the following must be exported by parent SConstruct/SConscript
 Import(
-    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile"
+    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability"
 )
 
 
@@ -209,6 +209,8 @@ if bootstrap:
 gctree_outbase = os.path.join(outdir, "gctree")
 frame_arg = " --frame {} ".format(frame) if frame is not None else ""
 idlabel_arg = " --idlabel" if idlabel else ""
+mutabilitymodel = " --mutability {}".format(mutability) if mutability else ""
+substitutionmodel = " --substitution {}".format(substitution) if substitution else ""
 gctree_infer = CommandRunner(
     [
         gctree_outbase + ".inference.parsimony_forest.p",
@@ -227,6 +229,9 @@ gctree_infer = CommandRunner(
     + idlabel_arg
     + (" --colormap ${SOURCES[-1]} " if colorfile is not None else "")
     + (" --bootstrap_phylipfile ${SOURCES[2]}" if bootstrap else "")
+    + (" --disambiguate_with_mutability" if disambiguate_with_mutability else "")
+    + mutabilitymodel
+    + substitutionmodel
     + " | tee ${TARGETS[1]}",
 )
 return_list.append(gctree_infer)

--- a/SConscript.inference
+++ b/SConscript.inference
@@ -18,7 +18,7 @@ def which(executable):
 
 # the following must be exported by parent SConstruct/SConscript
 Import(
-    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability"
+    "env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability extended_parsimony_search"
 )
 
 
@@ -209,8 +209,8 @@ if bootstrap:
 gctree_outbase = os.path.join(outdir, "gctree")
 frame_arg = " --frame {} ".format(frame) if frame is not None else ""
 idlabel_arg = " --idlabel" if idlabel else ""
-mutabilitymodel = " --mutability {}".format(mutability) if mutability else ""
-substitutionmodel = " --substitution {}".format(substitution) if substitution else ""
+mutabilitymodel = " --mutability {}".format(mutability) if disambiguate_with_mutability else ""
+substitutionmodel = " --substitution {}".format(substitution) if disambiguate_with_mutability else ""
 gctree_infer = CommandRunner(
     [
         gctree_outbase + ".inference.parsimony_forest.p",
@@ -232,6 +232,7 @@ gctree_infer = CommandRunner(
     + (" --disambiguate_with_mutability" if disambiguate_with_mutability else "")
     + mutabilitymodel
     + substitutionmodel
+    + (" --extended_parsimony_search" if extended_parsimony_search else "")
     + " | tee ${TARGETS[1]}",
 )
 return_list.append(gctree_infer)

--- a/SConstruct
+++ b/SConstruct
@@ -61,6 +61,28 @@ AddOption(
     action="store_true",
     help="use stdbuf to prevent line buffering on linux",
 )
+AddOption(
+    "--disambiguate_with_mutability",
+    action="store_true",
+    help="use mutability model provided using ``mutability'' and ``substitution'' arguments to attempt to optimally resolve ambiguities in dnapars output trees"
+)
+disambiguate_with_mutability = GetOption("disambiguate_with_mutability")
+AddOption(
+    "--mutability",
+    type="string",
+    metavar="PATH",
+    default="S5F/Mutability.csv",
+    help="path to S5F mutability data",
+)
+mutability = GetOption("mutability")
+AddOption(
+    "--substitution",
+    type="string",
+    metavar="PATH",
+    default="S5F/Substitution.csv",
+    help="path to S5F substitution data",
+)
+substitution = GetOption("substitution")
 buffarg = "stdbuf -oL " if GetOption("nobuff") else ""
 
 
@@ -86,22 +108,6 @@ if simulate:
         help="sequence of root from which to simulate",
     )
     root = GetOption("root")
-    AddOption(
-        "--mutability",
-        type="string",
-        metavar="PATH",
-        default="S5F/Mutability.csv",
-        help="path to S5F mutability data",
-    )
-    mutability = GetOption("mutability")
-    AddOption(
-        "--substitution",
-        type="string",
-        metavar="PATH",
-        default="S5F/Substitution.csv",
-        help="path to S5F substitution data",
-    )
-    substitution = GetOption("substitution")
     AddOption(
         "--lambda",
         type="float",
@@ -217,5 +223,5 @@ elif inference and not GetOption("help"):
         raise InputError("input fasta or phylip and outdir must be specified")
     SConscript(
         "SConscript.inference",
-        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile",
+        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability",
     )

--- a/SConstruct
+++ b/SConstruct
@@ -208,6 +208,12 @@ elif inference:
         help="boostrap resampling, and inference on each (default no bootstrap)",
     )
     bootstrap = GetOption("bootstrap")
+    AddOption(
+        "--extended_parsimony_search",
+        action="store_true",
+        help="search for more maximum parsimony trees using history DAG",
+    )
+    extended_parsimony_search = GetOption("extended_parsimony_search")
 
 # First call after all arguments have been parsed
 # to enable correct command line help.
@@ -223,5 +229,5 @@ elif inference and not GetOption("help"):
         raise InputError("input fasta or phylip and outdir must be specified")
     SConscript(
         "SConscript.inference",
-        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability",
+        exports="env dnaml quick idlabel frame input_file input_file2 outdir root_id id_abundances CommandRunner bootstrap xarg buffarg colorfile mutability substitution disambiguate_with_mutability extended_parsimony_search",
     )

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -687,9 +687,10 @@ def get_parser():
         type=str,
         default=None,
         help="path to substitution model file to be used with option ``disambiguate_with_mutability''",
+    )
     parser_infer.add_argument(
         "--extended_parsimony_search",
-        action="store_true"
+        action="store_true",
         help="search for more maximum parsimony trees using history DAG"
     )
     parser_infer.set_defaults(func=infer)

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -172,6 +172,7 @@ def infer(args):
             args.root,
             dist_func=dist_func,
             dependence_window=dependence_window,
+            extended_parsimony_search=args.extended_parsimony_search
         )
     ]
     if args.bootstrap_phylipfile is not None:
@@ -182,6 +183,7 @@ def infer(args):
                 args.root,
                 dist_func=dist_func,
                 dependence_window=dependence_window,
+                extended_parsimony_search=args.extended_parsimony_search
             )
         )
     bootstrap = len(outfiles) > 1
@@ -685,6 +687,10 @@ def get_parser():
         type=str,
         default=None,
         help="path to substitution model file to be used with option ``disambiguate_with_mutability''",
+    parser_infer.add_argument(
+        "--extended_parsimony_search",
+        action="store_true"
+        help="search for more maximum parsimony trees using history DAG"
     )
     parser_infer.set_defaults(func=infer)
 

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -172,7 +172,7 @@ def infer(args):
             args.root,
             dist_func=dist_func,
             dependence_window=dependence_window,
-            extended_parsimony_search=args.extended_parsimony_search
+            extended_parsimony_search=args.extended_parsimony_search,
         )
     ]
     if args.bootstrap_phylipfile is not None:
@@ -183,7 +183,7 @@ def infer(args):
                 args.root,
                 dist_func=dist_func,
                 dependence_window=dependence_window,
-                extended_parsimony_search=args.extended_parsimony_search
+                extended_parsimony_search=args.extended_parsimony_search,
             )
         )
     bootstrap = len(outfiles) > 1
@@ -691,7 +691,7 @@ def get_parser():
     parser_infer.add_argument(
         "--extended_parsimony_search",
         action="store_true",
-        help="search for more maximum parsimony trees using history DAG"
+        help="search for more maximum parsimony trees using history DAG",
     )
     parser_infer.set_defaults(func=infer)
 

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -193,7 +193,7 @@ def infer(args):
         # we'll store the mle gctrees here for computing support later
         gctrees = []
 
-    for i, content in enumerate(outfiles):
+    for i, dag in enumerate(outfiles):
         if i > 0:
             if args.verbose:
                 print(f"bootstrap sample {i}")
@@ -201,40 +201,16 @@ def infer(args):
             outbase = args.outbase + f".bootstrap_{i}"
         else:
             outbase = args.outbase
-        phylip_collapsed = [
-            bp.CollapsedTree(tree=tree, allow_repeats=(i > 0)) for tree in content
-        ]
-        phylip_collapsed_unique = []
-        for tree in phylip_collapsed:
-            if (
-                sum(
-                    tree.compare(tree2, method="identity")
-                    for tree2 in phylip_collapsed_unique
-                )
-                == 0
-            ):
-                phylip_collapsed_unique.append(tree)
 
-        parsimony_forest = bp.CollapsedForest(forest=phylip_collapsed_unique)
-
-        if parsimony_forest.n_trees == 1:
+        n_trees = dag.count_trees()
+        if n_trees == 1:
             warnings.warn("only one parsimony tree reported from dnapars")
 
         if args.verbose:
-            print(
-                "number of trees with integer branch lengths:", parsimony_forest.n_trees
-            )
+            print("number of trees with integer branch lengths:", n_trees)
 
-        # check for unifurcations at root
-        unifurcations = sum(
-            tree.tree.abundance == 0 and len(tree.tree.children) == 1
-            for tree in parsimony_forest.forest
-        )
-        if unifurcations and args.verbose:
-            print(
-                f"{unifurcations} trees exhibit unobserved unifurcation from"
-                " root. Adding psuedocounts to these roots"
-            )
+        cmcounters = dag.cmcounters()
+        cmlist = [[cm for cm in list(mset)] for mset in list(cmcounters.elements())]
 
         # fit p and q using all trees
         # if we get floating point errors, try a few more times
@@ -242,7 +218,9 @@ def infer(args):
         max_tries = 10
         for tries in range(max_tries):
             try:
-                p, q = parsimony_forest.mle(marginal=True)
+                p, q = bp._mle_helper(
+                    lambda p, q: bp.llforest(cmlist, p, q, marginal=True)
+                )
                 break
             except FloatingPointError as e:
                 if tries + 1 < max_tries and args.verbose:
@@ -256,6 +234,38 @@ def infer(args):
             else:
                 raise
 
+        if n_trees > 100:
+
+            def edge_weight_func(n1, n2):
+                """The _ll_genotype weight of the target node, unless it should be collapsed, then 0"""
+                if n2.is_leaf() and n2.label == n1.label:
+                    return 0.0
+                else:
+                    m = len(n2.clades)
+                    # Check if this edge should be collapsed, and reduce mutant descendants
+                    if frozenset({n2.label}) in n2.clades:
+                        m -= 1
+                    return bp.CollapsedTree._ll_genotype(n2.abundance, m, p, q)[0]
+
+            dag.trim_optimal_weight(edge_weight_func=edge_weight_func, optimal_func=max)
+
+        namedict = dag.seqidnamedict
+        counts = dag.seqidcounts
+
+        etetrees = [tree.to_ete(namedict=namedict) for tree in dag.get_trees()]
+        for tree in etetrees:
+            tree.name = args.root
+            for node in tree.traverse():
+                if not node.is_root():
+                    node.dist = utils.hamming_distance(node.sequence, node.up.sequence)
+                # Can only add nonzero abundance to leaves, because
+                # CollapsedTree init adds abundances when collapsing
+                # adjacent nodes with same sequence
+                if node.name in counts and node.is_leaf():
+                    node.add_feature("abundance", counts[node.name])
+                else:
+                    node.add_feature("abundance", 0)
+        parsimony_forest = bp.CollapsedForest(forest=[bp.CollapsedTree(tree) for tree in etetrees])
         if args.verbose:
             print(f"params: {(p, q)}")
 

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -156,10 +156,33 @@ def test(args):
 
 def infer(args):
     """inference subprogram."""
-    outfiles = [pp.parse_outfile(args.phylipfile, args.abundance_file, args.root)]
+    if args.disambiguate_with_mutability:
+        model = mm.MutationModel(
+            mutability_file=args.mutability, substitution_file=args.substitution
+        )
+        dist_func = utils.mutability_distance(model)
+        dependence_window = 2
+    else:
+        dist_func = utils.hamming_distance
+        dependence_window = 0
+    outfiles = [
+        pp.parse_outfile(
+            args.phylipfile,
+            args.abundance_file,
+            args.root,
+            dist_func=dist_func,
+            dependence_window=dependence_window,
+        )
+    ]
     if args.bootstrap_phylipfile is not None:
         outfiles.extend(
-            pp.parse_outfile(args.bootstrap_phylipfile, args.abundance_file, args.root)
+            pp.parse_outfile(
+                args.bootstrap_phylipfile,
+                args.abundance_file,
+                args.root,
+                dist_func=dist_func,
+                dependence_window=dependence_window,
+            )
         )
     bootstrap = len(outfiles) > 1
     if bootstrap:
@@ -645,6 +668,23 @@ def get_parser():
         type=str,
         default=None,
         help="positionmapfile for the 2nd chain when using the ``chain_split`` option",
+    )
+    parser_infer.add_argument(
+        "--disambiguate_with_mutability",
+        action="store_true",
+        help="use mutability model provided using ``mutability'' and ``substitution'' arguments to attempt to optimally resolve ambiguities in dnapars output trees",
+    )
+    parser_infer.add_argument(
+        "--mutability",
+        type=str,
+        default=None,
+        help="path to mutability model file to be used with option ``disambiguate_with_mutability''",
+    )
+    parser_infer.add_argument(
+        "--substitution",
+        type=str,
+        default=None,
+        help="path to substitution model file to be used with option ``disambiguate_with_mutability''",
     )
     parser_infer.set_defaults(func=infer)
 

--- a/gctree/mutation_model.py
+++ b/gctree/mutation_model.py
@@ -59,7 +59,6 @@ class MutationModel:
         else:
             self.context_model = None
 
-
     def mutability(self, kmer: str) -> Tuple[np.float64, np.float64]:
         r"""Returns the mutability of a central base of :math:`k`-mer, along with
         nucleotide bias averages over ambiguous ``"N"`` nucleotide identities.

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -129,14 +129,14 @@ def parse_outfile(outfile, abundance_file=None, root="root", **kwargs):
 
 
 def disambiguate(
-    tree: Tree, random_state=None, dist_func=hamming_distance, distance_dependence=0
+    tree: Tree, random_state=None, dist_func=hamming_distance, dependence_window=0
 ) -> Tree:
     """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
     subtrees of consecutive ambiguity codes.
     If passing a nonstandard distance function, the user must specify how many bases on either side of a focused base must be considered.
-    Distance_dependence is max distance a motif extends past focused
-    base, so a centered motif of length 5 has distance_dependence 2.
-    If the entire sequence should be disambiguated at once, use distance_dependence -1.
+    dependence_window is max distance a motif extends past focused
+    base, so a centered motif of length 5 has dependence_window 2.
+    If the entire sequence should be disambiguated at once, use dependence_window -1.
     """
 
     def is_ambiguous(sequence):
@@ -147,11 +147,11 @@ def disambiguate(
     else:
         random.setstate(random_state)
 
-    if distance_dependence == -1:
+    if dependence_window == -1:
         windows_to_disambiguate = [(0, len(tree.sequence))]
     else:
         # smash all sequences in tree into one, find windows containing
-        # ambiguities, padded by at least distance_dependence unambiguous bases
+        # ambiguities, padded by at least dependence_window unambiguous bases
         sequencelist = [node.sequence for node in tree.traverse()]
         is_ambiguous_collapsed = [
             any((sequence[index] not in bases for sequence in sequencelist))
@@ -162,13 +162,13 @@ def disambiguate(
         ]
 
         def is_window_beginning(ambig_index):
-            before_index = max([0, ambig_index - distance_dependence])
+            before_index = max([0, ambig_index - dependence_window])
             return not any(is_ambiguous_collapsed[before_index:ambig_index])
 
         def is_window_end(ambig_index):
             return not any(
                 is_ambiguous_collapsed[
-                    ambig_index + 1 : ambig_index + distance_dependence + 1
+                    ambig_index + 1 : ambig_index + dependence_window + 1
                 ]
             )
 
@@ -178,7 +178,7 @@ def disambiguate(
         window_ends = (index for index in ambiguous_indices if is_window_end(index))
         # tuples of starting and stopping indices which contain ambiguities in any of the sequences in sequencelist, including non-ambiguous padding around the ambiguities.
         windows_to_disambiguate = [
-            (max([0, a - distance_dependence]), b + distance_dependence + 1)
+            (max([0, a - dependence_window]), b + dependence_window + 1)
             for a, b in zip(window_beginnings, window_ends)
         ]
     for node in tree.traverse():

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -249,7 +249,13 @@ def disambiguate(
 
 # build a tree from a set of sequences and an adjacency dict.
 def build_tree(
-    sequences, parents, counts=None, root="root", dist_func=hamming_distance, disambiguate=True, **kwargs
+    sequences,
+    parents,
+    counts=None,
+    root="root",
+    dist_func=hamming_distance,
+    disambiguate=True,
+    **kwargs
 ):
     # build an ete tree
     # first a dictionary of disconnected nodes

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -228,7 +228,7 @@ def disambiguate(
                             for child in node2.children:
                                 seq_cost[1] += min(
                                     [
-                                        dist_func(child_seq, seq_cost[0])
+                                        dist_func(seq_cost[0], child_seq)
                                         + child_cost
                                         for child_seq, child_cost in child.costs
                                     ]
@@ -306,7 +306,7 @@ def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_d
         if len(root_parent.children) == 1:
             root_parent.delete(prevent_nondicotomic=False)
             root_parent.children[0].dist = dist_func(
-                root_parent.children[0].sequence, nodes[root_id].sequence
+                nodes[root_id].sequence, root_parent.children[0].sequence
             )
         tree = nodes[root_id]
 
@@ -316,7 +316,7 @@ def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_d
     # compute branch lengths
     tree.dist = 0  # no branch above root
     for node in tree.iter_descendants():
-        node.dist = dist_func(node.sequence, node.up.sequence)
+        node.dist = dist_func(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -125,7 +125,7 @@ def parse_outfile(
                             parents,
                             counts,
                             root,
-                            disambiguate_all=extended_parsimony_search,
+                            resolve_ambiguities=(not extended_parsimony_search),
                             **kwargs,
                         )
                     )
@@ -136,7 +136,7 @@ def parse_outfile(
                             parents,
                             counts,
                             root,
-                            disambiguate_all=extended_parsimony_search,
+                            resolve_ambiguities=(not extended_parsimony_search),
                             **kwargs,
                         )
                     )
@@ -151,8 +151,13 @@ def parse_outfile(
         # Will this mess with observed counts in MLE later?
         namedict = {sequence: name for name, sequence in sequences.items()}
         dag = historydag.dag.history_dag_from_etes(trees)
+        # Disambiguate (with later trimming step):
+        dag.expand_ambiguities()
+        # Look for (even) more trees:
         dag.add_all_allowed_edges(new_from_root=False, adjacent_labels=True)
         dag = dag.prune_min_weight()
+        # collapse zero-length edges so that all trees in dag are unique
+        # CollapsedTrees (reduces number that need to be exported from dag)
         dag.convert_to_collapsed()
         if len(dag.get_weight_counts()) > 1:
             # This could happen if something's wrong with history DAG theory,
@@ -163,6 +168,7 @@ def parse_outfile(
         trees = [fulltree.to_ete(namedict=namedict) for fulltree in dag.get_trees()]
         if counts is not None:
             for tree in trees:
+                tree.name = root
                 for node in tree.traverse():
                     if not node.is_root():
                         node.dist = hamming_distance(node.sequence, node.up.sequence)

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -126,7 +126,9 @@ def parse_outfile(outfile, abundance_file=None, root="root", **kwargs):
                         )
                     )
                 if bootstrap:
-                    trees[-1].append(build_tree(sequences, parents, counts, root, **kwargs ))
+                    trees[-1].append(
+                        build_tree(sequences, parents, counts, root, **kwargs)
+                    )
                 else:
                     trees.append(build_tree(sequences, parents, counts, root, **kwargs))
             elif sect == "seqboot_dataset":
@@ -228,8 +230,7 @@ def disambiguate(
                             for child in node2.children:
                                 seq_cost[1] += min(
                                     [
-                                        dist_func(seq_cost[0], child_seq)
-                                        + child_cost
+                                        dist_func(seq_cost[0], child_seq) + child_cost
                                         for child_seq, child_cost in child.costs
                                     ]
                                 )
@@ -276,7 +277,9 @@ def disambiguate(
 
 
 # build a tree from a set of sequences and an adjacency dict.
-def build_tree(sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs):
+def build_tree(
+    sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs
+):
     # build an ete tree
     # first a dictionary of disconnected nodes
     nodes = {}

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -249,7 +249,7 @@ def disambiguate(
 
 # build a tree from a set of sequences and an adjacency dict.
 def build_tree(
-    sequences, parents, counts=None, root="root", dist_func=hamming_distance, **kwargs
+    sequences, parents, counts=None, root="root", dist_func=hamming_distance, disambiguate=True, **kwargs
 ):
     # build an ete tree
     # first a dictionary of disconnected nodes
@@ -284,13 +284,14 @@ def build_tree(
             )
         tree = nodes[root_id]
 
-    # make random choices for ambiguous bases
-    tree = disambiguate(tree, dist_func=dist_func, **kwargs)
+    if disambiguate:
+        # make random choices for ambiguous bases
+        tree = disambiguate(tree, dist_func=dist_func, **kwargs)
 
-    # compute branch lengths
-    tree.dist = 0  # no branch above root
-    for node in tree.iter_descendants():
-        node.dist = dist_func(node.up.sequence, node.sequence)
+        # compute branch lengths
+        tree.dist = 0  # no branch above root
+        for node in tree.iter_descendants():
+            node.dist = dist_func(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -90,7 +90,9 @@ def parse_seqdict(fh, mode="dnaml"):
 # parse the dnaml output file and return data structures containing a
 # list biopython.SeqRecords and a dict containing adjacency
 # relationships and distances between nodes.
-def parse_outfile(outfile, abundance_file=None, root="root", extended_parsimony_search=False, **kwargs):
+def parse_outfile(
+    outfile, abundance_file=None, root="root", extended_parsimony_search=False, **kwargs
+):
     """parse phylip outfile."""
     if abundance_file is not None:
         counts = {
@@ -118,10 +120,26 @@ def parse_outfile(outfile, abundance_file=None, root="root", extended_parsimony_
                     )
                 if bootstrap:
                     trees[-1].extend(
-                        build_tree(sequences, parents, counts, root, disambiguate_all=extended_parsimony_search, **kwargs)
+                        build_tree(
+                            sequences,
+                            parents,
+                            counts,
+                            root,
+                            disambiguate_all=extended_parsimony_search,
+                            **kwargs,
+                        )
                     )
                 else:
-                    trees.extend(build_tree(sequences, parents, counts, root, disambiguate_all=extended_parsimony_search, **kwargs))
+                    trees.extend(
+                        build_tree(
+                            sequences,
+                            parents,
+                            counts,
+                            root,
+                            disambiguate_all=extended_parsimony_search,
+                            **kwargs,
+                        )
+                    )
             elif sect == "seqboot_dataset":
                 bootstrap = True
                 trees.append([])
@@ -287,7 +305,7 @@ def build_tree(
     dist_func=hamming_distance,
     resolve_ambiguities=True,
     disambiguate_all=False,
-    **kwargs
+    **kwargs,
 ):
     # build an ete tree
     # first a dictionary of disconnected nodes

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -254,7 +254,7 @@ def build_tree(
     counts=None,
     root="root",
     dist_func=hamming_distance,
-    disambiguate=True,
+    resolve_ambiguities=True,
     **kwargs
 ):
     # build an ete tree
@@ -285,19 +285,22 @@ def build_tree(
         # remove possible unecessary unifurcation after rerooting
         if len(root_parent.children) == 1:
             root_parent.delete(prevent_nondicotomic=False)
-            root_parent.children[0].dist = dist_func(
+            # this must stay hamming_distance, not dist_func
+            # used for collapsing logic.
+            root_parent.children[0].dist = hamming_distance(
                 nodes[root_id].sequence, root_parent.children[0].sequence
             )
         tree = nodes[root_id]
 
-    if disambiguate:
+    if resolve_ambiguities:
         # make random choices for ambiguous bases
         tree = disambiguate(tree, dist_func=dist_func, **kwargs)
 
         # compute branch lengths
         tree.dist = 0  # no branch above root
         for node in tree.iter_descendants():
-            node.dist = dist_func(node.up.sequence, node.sequence)
+            # This must stay hamming_distance, not dist_func
+            node.dist = hamming_distance(node.up.sequence, node.sequence)
 
     return tree
 

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -94,6 +94,9 @@ def parse_outfile(
     outfile, abundance_file=None, root="root", extended_parsimony_search=False, **kwargs
 ):
     """parse phylip outfile."""
+    if 'resolve_ambiguities' in kwargs:
+        if 'resolve_ambiguities' == True:
+            kwargs.update(resolve_ambiguities=(not extended_parsimony_search))
     if abundance_file is not None:
         counts = {
             line.split(",")[0]: int(line.split(",")[1]) for line in open(abundance_file)
@@ -125,7 +128,6 @@ def parse_outfile(
                             parents,
                             counts,
                             root,
-                            resolve_ambiguities=(not extended_parsimony_search),
                             **kwargs,
                         )
                     )
@@ -136,7 +138,6 @@ def parse_outfile(
                             parents,
                             counts,
                             root,
-                            resolve_ambiguities=(not extended_parsimony_search),
                             **kwargs,
                         )
                     )
@@ -150,6 +151,7 @@ def parse_outfile(
         # disambiguated sequence will be named "unnamed_seq"
         # Will this mess with observed counts in MLE later?
         namedict = {sequence: name for name, sequence in sequences.items()}
+        print(f"Starting with {len(trees)} trees")
         dag = historydag.dag.history_dag_from_etes(trees)
         # Disambiguate (with later trimming step):
         dag.expand_ambiguities()
@@ -159,6 +161,7 @@ def parse_outfile(
         # collapse zero-length edges so that all trees in dag are unique
         # CollapsedTrees (reduces number that need to be exported from dag)
         dag.convert_to_collapsed()
+        print(f"DAG contains {dag.count_trees()} collapsed trees")
         if len(dag.get_weight_counts()) > 1:
             # This could happen if something's wrong with history DAG theory,
             # or convert_to_collapsed has a bug

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -155,7 +155,7 @@ def parse_outfile(
         dag.expand_ambiguities()
         # Look for (even) more trees:
         dag.add_all_allowed_edges(new_from_root=False, adjacent_labels=True)
-        dag = dag.prune_min_weight()
+        dag.trim_min_weight()
         # collapse zero-length edges so that all trees in dag are unique
         # CollapsedTrees (reduces number that need to be exported from dag)
         dag.convert_to_collapsed()

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,8 +1,9 @@
+from math import log
+
 r"""Utility functions."""
 
 
 def check_distance_arguments(distance):
-
     def new_distance(seq1: str, seq2: str, *args, **kwargs):
         if len(seq1) != len(seq2):
             raise ValueError(
@@ -11,6 +12,7 @@ def check_distance_arguments(distance):
         return distance(seq1, seq2, *args, **kwargs)
 
     return new_distance
+
 
 @check_distance_arguments
 def hamming_distance(seq1: str, seq2: str) -> int:
@@ -22,15 +24,22 @@ def hamming_distance(seq1: str, seq2: str) -> int:
     """
     return sum(x != y for x, y in zip(seq1, seq2))
 
+
 @check_distance_arguments
 def mutability_distance(seq1: str, seq2: str, mutability_model) -> float:
-    """Assume that sequences being compared are already padded, so this will be a sum of
-    negative log biases over bases within the padding margin...but that will be a problem
-    when there's an ambiguity at the beginning of the sequence"""
+    """Assume that sequences being compared are already padded, so this will be
+    a sum of negative log biases over bases within the padding margin...but
+    that will be a problem when there's an ambiguity at the beginning of the
+    sequence."""
     mutabilities = mutability_model.mutabilities(seq1)
     normalizing_constant = sum(mut for mut, _ in mutabilities)
-    normalized_mutabilities = [(mut / normalizing_constant, biases) for mut, biases in mutabilities]
-    transition_costs = [-log(mut[0] * mut[1][seq2[index]]) if seq1[index] == seq2[index]
-                        else -log(1-mut[0])
-                        for index, mutability in enumerate(mutabilities)]
+    normalized_mutabilities = [
+        (mut / normalizing_constant, biases) for mut, biases in mutabilities
+    ]
+    transition_costs = [
+        -log(mut[0] * mut[1][seq2[index]])
+        if seq1[index] == seq2[index]
+        else -log(1 - mut[0])
+        for index, mut in enumerate(normalized_mutabilities)
+    ]
     return sum(transition_costs)

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -86,6 +86,10 @@ def mutability_distance(mutation_model):
         a sum of negative log biases over bases within the padding margin...but
         that will be a problem when there's an ambiguity at the beginning of the
         sequence."""
+        if len(seq1) < 2:
+            raise ValueError(
+                "mutability distance function can only compare sequences of more than one base"
+            )
         muts = mutabilities(seq1)
         nc = sum(mut for mut, _ in muts)
         return sum(

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -6,6 +6,7 @@ r"""Utility functions."""
 bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
 
+
 def disambiguations(sequence, accum=""):
     """Iterates through possible disambiguations of sequence, recursively.
     Recursion-depth-limited by number of ambiguity codes in
@@ -22,6 +23,7 @@ def disambiguations(sequence, accum=""):
                     )
                 return
     yield accum
+
 
 def check_distance_arguments(distance):
     def new_distance(seq1: str, seq2: str, *args, **kwargs):
@@ -55,10 +57,12 @@ def mutability_distance(mutation_model):
     k = mutation_model.k
     h = k // 2
     # Build all sequences with (when k=5) one or two Ns on either end
-    templates = [("N"* left, "N" * (k - left - right), "N" * right)
-                 for left in range(h + 1)
-                 for right in range(h + 1)
-                 if left != 0 or right != 0]
+    templates = [
+        ("N" * left, "N" * (k - left - right), "N" * right)
+        for left in range(h + 1)
+        for right in range(h + 1)
+        if left != 0 or right != 0
+    ]
 
     kmers_to_compute = [
         leftns + stub + rightns
@@ -66,7 +70,9 @@ def mutability_distance(mutation_model):
         for stub in disambiguations(ambig_stub)
     ]
     # Cache all these mutabilities in context_model also
-    context_model.update({kmer: mutation_model.mutability(kmer) for kmer in kmers_to_compute})
+    context_model.update(
+        {kmer: mutation_model.mutability(kmer) for kmer in kmers_to_compute}
+    )
 
     def mutabilities(seq):
         newseq = "N" * h + seq + "N" * h

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,6 +1,18 @@
 r"""Utility functions."""
 
 
+def check_distance_arguments(distance):
+
+    def new_distance(seq1: str, seq2: str, *args, **kwargs):
+        if len(seq1) != len(seq2):
+            raise ValueError(
+                f"sequences must have equal length, got {len(seq1)} and {len(seq2)}"
+            )
+        return distance(seq1, seq2, *args, **kwargs)
+
+    return new_distance
+
+@check_distance_arguments
 def hamming_distance(seq1: str, seq2: str) -> int:
     r"""Hamming distance between two sequences of equal length.
 
@@ -8,10 +20,17 @@ def hamming_distance(seq1: str, seq2: str) -> int:
         seq1: sequence 1
         seq2: sequence 2
     """
-
-    if len(seq1) != len(seq2):
-        raise ValueError(
-            f"sequences must have equal length, got {len(seq1)} and {len(seq2)}"
-        )
-
     return sum(x != y for x, y in zip(seq1, seq2))
+
+@check_distance_arguments
+def mutability_distance(seq1: str, seq2: str, mutability_model) -> float:
+    """Assume that sequences being compared are already padded, so this will be a sum of
+    negative log biases over bases within the padding margin...but that will be a problem
+    when there's an ambiguity at the beginning of the sequence"""
+    mutabilities = mutability_model.mutabilities(seq1)
+    normalizing_constant = sum(mut for mut, _ in mutabilities)
+    normalized_mutabilities = [(mut / normalizing_constant, biases) for mut, biases in mutabilities]
+    transition_costs = [-log(mut[0] * mut[1][seq2[index]]) if seq1[index] == seq2[index]
+                        else -log(1-mut[0])
+                        for index, mutability in enumerate(mutabilities)]
+    return sum(transition_costs)

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -7,7 +7,7 @@ bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
 
 
-def disambiguations(sequence, accum=""):
+def disambiguations(sequence, _accum=""):
     """Iterates through possible disambiguations of sequence, recursively.
     Recursion-depth-limited by number of ambiguity codes in
     sequence, not sequence length.
@@ -15,14 +15,14 @@ def disambiguations(sequence, accum=""):
     if sequence:
         for index, base in enumerate(sequence):
             if base in bases:
-                accum += base
+                _accum += base
             else:
                 for newbase in ambiguous_dna_values[base]:
                     yield from disambiguations(
-                        sequence[index + 1 :], accum=(accum + newbase)
+                        sequence[index + 1 :], _accum=(_accum + newbase)
                     )
                 return
-    yield accum
+    yield _accum
 
 
 def check_distance_arguments(distance):

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -76,7 +76,8 @@ def test_restricted_ambiguity():
         print(f"\nDisambiguate function is missing {missing}\n"
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
-    
+
+
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=3)
     correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -108,3 +108,37 @@ def test_restricted_ambiguity_widewindow():
         print(f"\nDisambiguate function is missing {missing}\n"
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
+
+def test_sequence_disambiguate():
+    sequences = ["GVNT", "?TCM"]
+    lsts = [list(utils.disambiguations(sequence)) for sequence in sequences]
+    correctsets = [
+        {"GAAT",
+         "GACT",
+         "GAGT",
+         "GATT",
+         "GCAT",
+         "GCCT",
+         "GCGT",
+         "GCTT",
+         "GGAT",
+         "GGCT",
+         "GGGT",
+         "GGTT"},
+        {"ATCA",
+         "ATCC",
+         "GTCA",
+         "GTCC",
+         "CTCA",
+         "CTCC",
+         "TTCA",
+         "TTCC",
+         "-TCA",
+         "-TCC"}
+    ]
+    for seq, lst, correctset in zip(sequences, lsts, correctsets):
+        if not len(lst) == len(set(lst)):
+            raise ValueError("Non-unique sequence disambiguation")
+        if not set(lst) == correctset:
+            raise ValueError(f"Incorrect disambiguation of sequence {seq}:\n{lst}")
+

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -1,3 +1,4 @@
+from gctree import mutation_model, utils
 import random
 import ete3
 import gctree.phylip_parse as pps
@@ -35,13 +36,14 @@ def treeprint(tree: ete3.TreeNode):
     return(tree.write(format=8))
 
 
-def sample(tree, n=20, distance_dependence=0):
+def sample(tree, n=20, **kwargs):
     print(tree.sequence)
     newickset = set()
     for i in range(n):
         t = tree.copy()
         random.seed(i)
-        t = pps.disambiguate(t, random_state=random.getstate(), distance_dependence=distance_dependence)
+        t = pps.disambiguate(t, random_state=random.getstate(), **kwargs)
+        print(treeprint(t))
         newickset.add(treeprint(t))
     return(newickset)
 
@@ -77,6 +79,17 @@ def test_restricted_ambiguity():
               f"and came up with these incorrect trees: {wrong}")
         raise ValueError("Invalid Disambiguation")
 
+
+def test_restricted_ambiguity_widewindow_mutability():
+    mmodel = mutation_model.MutationModel(mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv")
+    newickset = sample(tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2)
+    correctset = {'((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);'}
+    if not newickset == correctset:
+        missing = correctset - newickset
+        wrong = newickset - correctset
+        print(f"\nDisambiguate function is missing {missing}\n"
+              f"and came up with these incorrect trees: {wrong}")
+        raise ValueError("Invalid Disambiguation")
 
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=3)

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -3,21 +3,25 @@ import random
 import ete3
 import gctree.phylip_parse as pps
 
-newick_tree1 = ("((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
-                "(6[&&NHX:name=6:sequence=C],"
-                "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=M])"
-                "3[&&NHX:name=3:sequence=M],8[&&NHX:name=8:sequence=A],"
-                "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
-                "9[&&NHX:name=9:sequence=R])2[&&NHX:name=2:sequence=R])"
-                "1[&&NHX:name=1:sequence=G];")
+newick_tree1 = (
+    "((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
+    "(6[&&NHX:name=6:sequence=C],"
+    "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=M])"
+    "3[&&NHX:name=3:sequence=M],8[&&NHX:name=8:sequence=A],"
+    "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
+    "9[&&NHX:name=9:sequence=R])2[&&NHX:name=2:sequence=R])"
+    "1[&&NHX:name=1:sequence=G];"
+)
 
-newick_tree2 = ("((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
-                "(6[&&NHX:name=6:sequence=C],"
-                "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=?])"
-                "3[&&NHX:name=3:sequence=?],8[&&NHX:name=8:sequence=A],"
-                "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
-                "9[&&NHX:name=9:sequence=?])2[&&NHX:name=2:sequence=?])"
-                "1[&&NHX:name=1:sequence=G];")
+newick_tree2 = (
+    "((((12[&&NHX:name=12:sequence=T])4[&&NHX:name=4:sequence=C],"
+    "(6[&&NHX:name=6:sequence=C],"
+    "7[&&NHX:name=7:sequence=A])5[&&NHX:name=5:sequence=?])"
+    "3[&&NHX:name=3:sequence=?],8[&&NHX:name=8:sequence=A],"
+    "(11[&&NHX:name=11:sequence=A],10[&&NHX:name=10:sequence=G])"
+    "9[&&NHX:name=9:sequence=?])2[&&NHX:name=2:sequence=?])"
+    "1[&&NHX:name=1:sequence=G];"
+)
 
 tree1 = ete3.TreeNode(newick=newick_tree1, format=1)
 for node in tree1.traverse():
@@ -33,7 +37,7 @@ def treeprint(tree: ete3.TreeNode):
     tree = tree.copy()
     for node in tree.traverse():
         node.name = node.sequence
-    return(tree.write(format=8))
+    return tree.write(format=8)
 
 
 def sample(tree, n=20, **kwargs):
@@ -45,100 +49,123 @@ def sample(tree, n=20, **kwargs):
         t = pps.disambiguate(t, random_state=random.getstate(), **kwargs)
         print(treeprint(t))
         newickset.add(treeprint(t))
-    return(newickset)
+    return newickset
 
 
 def test_full_ambiguity():
     newickset = sample(tree2)
-    correctset = {"((((T)C,(C,A)C)C,A,(A,G)G)G);",
-                  "((((T)C,(C,A)A)A,A,(A,G)A)A);",
-                  "((((T)C,(C,A)C)C,A,(A,G)A)A);"}
+    correctset = {
+        "((((T)C,(C,A)C)C,A,(A,G)G)G);",
+        "((((T)C,(C,A)A)A,A,(A,G)A)A);",
+        "((((T)C,(C,A)C)C,A,(A,G)A)A);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
 
 
 def test_restricted_ambiguity():
     newickset = sample(tree1)
-    correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);'}
+    correctset = {
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
 
 
 def test_restricted_ambiguity_widewindow_mutability():
-    mmodel = mutation_model.MutationModel(mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv")
-    newickset = sample(tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2)
-    correctset = {'((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);'}
+    mmodel = mutation_model.MutationModel(
+        mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv"
+    )
+    newickset = sample(
+        tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2
+    )
+    correctset = {"((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);"}
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
+
 
 def test_restricted_ambiguity_widewindow():
     newickset = sample(tree1, n=100, distance_dependence=-1)
-    correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);',
-                  '((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);',
-                  '((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);',
-                  '((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);'}
+    correctset = {
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GA)GA);",
+        "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)AG)AG);",
+        "((((TT)CC,(CC,AA)AA)AA,AA,(AA,GG)AA)AA);",
+        "((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)AA)AA);",
+    }
     if not newickset == correctset:
         missing = correctset - newickset
         wrong = newickset - correctset
-        print(f"\nDisambiguate function is missing {missing}\n"
-              f"and came up with these incorrect trees: {wrong}")
+        print(
+            f"\nDisambiguate function is missing {missing}\n"
+            f"and came up with these incorrect trees: {wrong}"
+        )
         raise ValueError("Invalid Disambiguation")
+
 
 def test_sequence_disambiguate():
     sequences = ["GVNT", "?TCM"]
     lsts = [list(utils.disambiguations(sequence)) for sequence in sequences]
     correctsets = [
-        {"GAAT",
-         "GACT",
-         "GAGT",
-         "GATT",
-         "GCAT",
-         "GCCT",
-         "GCGT",
-         "GCTT",
-         "GGAT",
-         "GGCT",
-         "GGGT",
-         "GGTT"},
-        {"ATCA",
-         "ATCC",
-         "GTCA",
-         "GTCC",
-         "CTCA",
-         "CTCC",
-         "TTCA",
-         "TTCC",
-         "-TCA",
-         "-TCC"}
+        {
+            "GAAT",
+            "GACT",
+            "GAGT",
+            "GATT",
+            "GCAT",
+            "GCCT",
+            "GCGT",
+            "GCTT",
+            "GGAT",
+            "GGCT",
+            "GGGT",
+            "GGTT",
+        },
+        {
+            "ATCA",
+            "ATCC",
+            "GTCA",
+            "GTCC",
+            "CTCA",
+            "CTCC",
+            "TTCA",
+            "TTCC",
+            "-TCA",
+            "-TCC",
+        },
     ]
     for seq, lst, correctset in zip(sequences, lsts, correctsets):
         if not len(lst) == len(set(lst)):
             raise ValueError("Non-unique sequence disambiguation")
         if not set(lst) == correctset:
             raise ValueError(f"Incorrect disambiguation of sequence {seq}:\n{lst}")
-

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -92,7 +92,7 @@ def test_restricted_ambiguity_widewindow_mutability():
         raise ValueError("Invalid Disambiguation")
 
 def test_restricted_ambiguity_widewindow():
-    newickset = sample(tree1, n=100, distance_dependence=3)
+    newickset = sample(tree1, n=100, distance_dependence=-1)
     correctset = {'((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);',
                   '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);',
                   '((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AA)AA);',

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -97,7 +97,7 @@ def test_restricted_ambiguity_widewindow_mutability():
         mutability_file="S5F/Mutability.csv", substitution_file="S5F/Substitution.csv"
     )
     newickset = sample(
-        tree1, n=5, dist_func=utils.mutability_distance(mmodel), distance_dependence=2
+        tree1, n=5, dist_func=utils.mutability_distance(mmodel), dependence_window=2
     )
     correctset = {"((((TT)CC,(CC,AA)CA)CA,AA,(AA,GG)GA)GA);"}
     if not newickset == correctset:
@@ -111,7 +111,7 @@ def test_restricted_ambiguity_widewindow_mutability():
 
 
 def test_restricted_ambiguity_widewindow():
-    newickset = sample(tree1, n=100, distance_dependence=-1)
+    newickset = sample(tree1, n=100, dependence_window=-1)
     correctset = {
         "((((TT)CC,(CC,AA)CC)CC,AA,(AA,GG)GG)GG);",
         "((((TT)CC,(CC,AA)AC)AC,AA,(AA,GG)AG)AG);",


### PR DESCRIPTION
## Goal:
Use the history DAG to swap substructures in maximum parsimony trees output by dnapars, resulting in a much larger number of maximum parsimony trees for model fitting and ranking in the gctree inference pipeline.

Just a taste of what we're missing: with the default seed, running dnapars on the sample data yields 263 maximum parsimony trees, before disambiguating and collapsing. After default disambiguation and collapsing process, gctree starts inference with 203 maximum parsimony CollapsedTrees.

The 263 ambiguous trees output by dnapars yield 423 possible (not necessarily unique, not collapsed) maximum parsimony disambiguations, which can be used to find 703 unique, collapsed maximum parsimony trees using the history DAG. These include the 203 trees found by the default method, and 500 more. Using these extra trees could improve inference.
Here's some output from the sample data, with inferred parameters and tree ranking using all 703 trees. Lines marked with an asterisk are trees that were not one of the original 203 collapsed trees.
```
params:     (0.49618320692429585, 0.36445206621349757)
tree    new     alleles logLikelihood
1               48      -78.00393661325725
2       *       48      -78.00393661325725
3       *       48      -78.00393661325725
4       *       48      -79.01553752493574
5       *       48      -79.01553752493574
6       *       48      -79.01553752493574
7       *       48      -79.10254890192536
8       *       48      -79.10254890192536
9       *       48      -79.21224781918178
10      *       48      -79.21224781918178
11      *       48      -79.21224781918178
12      *       48      -79.21224781918178
13              48      -79.81838362275211
14              48      -79.81838362275211
15              48      -79.81838362275211
16              48      -80.0877165565357
17              48      -80.0877165565357
18      *       48      -80.11414981360385
19      *       48      -80.11414981360386
20      *       48      -80.22384873086027
21      *       48      -80.22384873086027
22      *       48      -80.22384873086027
23      *       48      -80.22384873086027
24              48      -80.3108601078499
25              49      -80.35178855994307
26              49      -80.35178855994307
27              49      -80.35178855994307
28              49      -80.35178855994309
29      *       49      -80.4614874771995
30              49      -80.46148747719951
31              49      -80.46148747719951
32              49      -80.46148747719951
33              49      -80.46148747719951
34              49      -80.46148747719951
35              49      -80.46148747719951
36      *       49      -80.46148747719951
37      *       49      -80.46148747719951
38      *       49      -80.46148747719951
39      *       49      -80.46148747719951
40              48      -80.91699591142022
.
.
.
```

## Description of Changes:
* Add option `extended_parsimony_search` to `phylip_parse.parse_outfile`. When True,
    * ambiguous sequences in trees output by dnapars are resolved in all possible (maximally parsimonious) ways
    * resolved trees output by dnapars are then used to create a history DAG, to which all allowed edges are added
    * the DAG is trimmed so that it only expresses maximum parsimony trees
    * an algorithm to eliminate edges between nodes with the same label (sequence) is run on the DAG
    * trees represented by the DAG are returned. These trees have the same leaf sequences, names, and abundances as the trees used to construct the DAG. They also have the same root sequence and name, are guaranteed to yield unique `CollapsedTree` objects
* Add option `--extended_parsimony_search` to scons inference pipeline and gctree cli.

## Tests
* passes existing tests
*  works as expected on sample data with
```
scons --inference --input=example/150228_Clone_3-8.fasta --outdir=_build --id_abundances --root_id=GL --jobs=2 --extended_parsimony_search
```