### PR TITLE
Add ambiguous sequence test and error message

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1505,10 +1505,13 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
     # Assume all trees have fixed root sequence and fixed leaf sequences
     def get_sequence(node):
         if any(base not in gctree.utils.bases for base in node.sequence):
-            raise ValueError(f"Unrecognized base found in node '{node.name}'. "
-                             "Ambiguous bases are not permitted in observed sequences.")
+            raise ValueError(
+                f"Unrecognized base found in node '{node.name}'. "
+                "Ambiguous bases are not permitted in observed sequences."
+            )
         else:
             return node.sequence
+
     leaf_seqs = {get_sequence(node) for node in trees[0].get_leaves()}
 
     sequence_counts = sequence_counts.copy()

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1503,7 +1503,13 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
     have abundance, name, and sequence attributes."""
     # preprocess trees so they're acceptable inputs
     # Assume all trees have fixed root sequence and fixed leaf sequences
-    leaf_seqs = {node.sequence for node in trees[0].get_leaves()}
+    def get_sequence(node):
+        if any(base not in gctree.utils.bases for base in node.sequence):
+            raise ValueError(f"Unrecognized base found in node '{node.name}'. "
+                             "Ambiguous bases are not permitted in observed sequences.")
+        else:
+            return node.sequence
+    leaf_seqs = {get_sequence(node) for node in trees[0].get_leaves()}
 
     sequence_counts = sequence_counts.copy()
     if from_copy:
@@ -1546,9 +1552,9 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
             "Parsimony trees have too many ambiguities for disambiguation in history DAG. "
             "Disambiguating trees individually. History DAG may find fewer new parsimony trees."
         )
-        trees = [disambiguate(tree) for tree in trees]
+        distrees = [disambiguate(tree) for tree in trees]
         dag = hdag.history_dag_from_etes(
-            trees,
+            distrees,
             ["sequence"],
             attr_func=lambda n: {
                 "name": n.name,


### PR DESCRIPTION
This PR simply adds a test for ambiguous leaf sequences in the first (dnapars) tree in the list passed to `branching_processes._make_dag`, printing an informative error message if any are found.

Changes pass all tests and are triggered by the inputs that inspired this PR.