### PR TITLE
Store isotype data in nodes

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1109,6 +1109,17 @@ class CollapsedForest:
             if verbose:
                 print("Isotype parsimony will not be used as a ranking criterion")
         else:
+            # Check for missing isotype data in all but root node, and fake root-adjacent leaf node
+            if any(
+                not node.attr["isotype"]
+                for node in self._forest.preorder()
+                if not node.is_root() and node.attr["name"] != ""
+            ):
+                warnings.warn(
+                    "Some isotype data may be missing, or `add_isotypes` wasn't called "
+                    "on this CollapsedForest instance. Isotype parsimony scores may be incorrect."
+                )
+
             iso_funcs = _isotype_dagfuncs()
         if mutability_file and substitution_file:
             mut_funcs = _mutability_dagfuncs(

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -520,7 +520,8 @@ def get_parser():
             "dnapars outfile (verbose output with sequences at each site), and the second "
             "shall be an abundance file containing allele frequencies (sequence counts) in "
             "the format: ``SeqID, Nobs``. If a single filename is passed, it shall be the name "
-            "of a pickled history DAG object created by gctree."
+            "of a pickled history DAG object created by gctree. A new pickled forest will be "
+            "output only if new annotations (such as isotypes) are added."
         ),
     )
     parser_infer.add_argument(

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -156,6 +156,14 @@ def test(args):
 
 def infer(args):
     """inference subprogram."""
+
+    def isotype_add(forest):
+        forest.add_isotypes(
+            isotypemap_file=args.isotype_mapfile,
+            idmap_file=args.idmapfile,
+            isotype_names=args.isotype_names,
+        )
+
     if len(args.infiles) == 2:
         forest = bp.CollapsedForest(
             *pp.parse_outfile(args.infiles[0], args.infiles[1], args.root)
@@ -170,6 +178,9 @@ def infer(args):
                 forest.n_topologies(),
             )
         forest.mle(marginal=True)
+        # Add isotypes to forest
+        if args.isotype_mapfile:
+            isotype_add(forest)
         with open(args.outbase + ".inference.parsimony_forest.p", "wb") as f:
             pickle.dump(forest, f)
 
@@ -180,22 +191,14 @@ def infer(args):
             )
         with open(args.infiles[0], "rb") as fh:
             forest = pickle.load(fh)
+        # Add isotypes to forest and re-pickle if necessary
+        if args.isotype_mapfile:
+            isotype_add(forest)
+            with open(args.outbase + ".inference.parsimony_forest.p", "wb") as f:
+                pickle.dump(forest, f)
     else:
         raise ValueError(
             "The filename of a pickled history DAG object, or a phylipfile and abundance file, are required."
-        )
-
-    if args.verbose and args.mutability and args.substitution:
-        print("Mutation model parsimony will be used as a ranking criterion")
-
-    # Add isotypes to forest
-    if args.isotype_mapfile:
-        if args.verbose:
-            print("Isotype parsimony will be used as a ranking criterion")
-        forest.add_isotypes(
-            isotypemap_file=args.isotype_mapfile,
-            idmap_file=args.idmapfile,
-            isotype_names=args.isotype_names,
         )
 
     # Filter the forest according to specified criteria, and along the way,

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -185,6 +185,19 @@ def infer(args):
             "The filename of a pickled history DAG object, or a phylipfile and abundance file, are required."
         )
 
+    if args.verbose and args.mutability and args.substitution:
+        print("Mutation model parsimony will be used as a ranking criterion")
+
+    # Add isotypes to forest
+    if args.isotype_mapfile:
+        if args.verbose:
+            print("Isotype parsimony will be used as a ranking criterion")
+        forest.add_isotypes(
+            isotypemap_file=args.isotype_mapfile,
+            idmap_file=args.idmapfile,
+            isotype_names=args.isotype_names,
+        )
+
     # Filter the forest according to specified criteria, and along the way,
     # write a log file containing stats for all trees in the forest:
     trimmed_forest, _ = forest.filter_trees(
@@ -195,9 +208,6 @@ def infer(args):
         tree_stats=args.tree_stats,
         mutability_file=args.mutability,
         substitution_file=args.substitution,
-        isotypemap_file=args.isotype_mapfile,
-        idmap_file=args.idmapfile,
-        isotype_names=args.isotype_names,
     )
 
     if args.verbose:

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -5,9 +5,10 @@ from gctree.utils import hamming_distance
 import random
 import ete3
 import warnings
-from typing import Dict, Callable, Optional, Set, Sequence, Mapping, Tuple, FrozenSet
+from typing import Dict, Callable, Optional, Set, Sequence, Mapping, Tuple
 from functools import wraps
 import historydag as hdag
+from frozendict import frozendict
 
 default_isotype_order = ["IgM", "IgD", "IgG3", "IgG1", "IgG2", "IgE", "IgA"]
 
@@ -385,18 +386,53 @@ def explode_idmap(
     return newidmap
 
 
-def _isotype_dagfuncs(
+def _isotype_dagfuncs() -> hdag.utils.AddFuncDict:
+    """Return functions for filtering by isotype parsimony score on the history
+    DAG.
+
+    The DAG on which these functions is run should have key ``isotype`` in their attr dictionaries.
+    The :meth:``CollapsedForest.add_isotypes`` method can be used to achieve this.
+    If isotypes aren't added, these functions will return a weight of 0 for all trees.
+
+    Isotype parsimony of a tree is the minimum number of allowed isotype transitions
+    required along all edges.
+
+    Returns:
+        A :meth:`historydag.utils.AddFuncDict` which may be passed as keyword arguments
+        to :meth:`historydag.HistoryDag.weight_count`, :meth:`historydag.HistoryDag.trim_optimal_weight`,
+        or :meth:`historydag.HistoryDag.optimal_weight_annotate`
+        methods to trim or annotate a :meth:`historydag.HistoryDag` according to isotype parsimony.
+        Weight type is ``int``."""
+
+    def edge_weight_func(n1: hdag.HistoryDagNode, n2: hdag.HistoryDagNode):
+        if n1.is_root():
+            return 0
+        else:
+            n1isos = n1.attr["isotype"]
+            n2isos = n2.attr["isotype"]
+            if not n1isos or not n2isos:
+                return 0
+            n1iso = list(n1isos.keys())[0]
+            return int(sum(isotype_distance(n1iso, n2iso) for n2iso in n2isos.keys()))
+
+    return hdag.utils.AddFuncDict(
+        {
+            "start_func": lambda n: 0,
+            "edge_weight_func": edge_weight_func,
+            "accum_func": sum,
+        },
+        name="Isotype Pars.",
+    )
+
+
+def _isotype_annotation_dagfuncs(
     isotypemap: Mapping[str, str] = None,
     isotypemap_file: str = None,
     idmap: Mapping[str, Set[str]] = None,
     idmap_file: str = None,
     isotype_names: Sequence[str] = None,
 ) -> hdag.utils.AddFuncDict:
-    """Return functions for filtering by isotype parsimony score on the history
-    DAG.
-
-    Isotype parsimony of a tree is the minimum number of allowed isotype transitions
-    required along all edges.
+    """Return functions for annotating history DAG nodes with inferred isotypes.
 
     Args:
         isotypemap: A dictionary mapping original IDs to observed isotype names
@@ -410,8 +446,8 @@ def _isotype_dagfuncs(
         to :meth:`historydag.HistoryDag.weight_count`, :meth:`historydag.HistoryDag.trim_optimal_weight`,
         or :meth:`historydag.HistoryDag.optimal_weight_annotate`
         methods to trim or annotate a :meth:`historydag.HistoryDag` according to isotype parsimony.
-        Weight format is ``(score, isotypeset)``, where ``score`` is isotype parsimony as a float,
-        and ``isotypeset`` is a frozenset containing isotypes used internally for computing parsimony score.
+        Weight format is ``frozendict[Isotype, int]``, where the value is the count of observed isotypes, and 0
+        for unobserved (internal) nodes.
     """
     if isotype_names is None:
         isotype_names = default_isotype_order
@@ -435,34 +471,30 @@ def _isotype_dagfuncs(
     newidmap = explode_idmap(idmap, isotypemap)
     newisotype = IsotypeTemplate(isotype_names, weight_matrix=None).new
 
-    def distance_func(n1: hdag.HistoryDagNode, n2: hdag.HistoryDagNode):
-        if n2.is_leaf():
-            seqid = n2.attr["name"]
-            if seqid in newidmap:
-                isoset = frozenset(newisotype(name) for name in newidmap[seqid].keys())
-            else:
-                isoset = frozenset()
+    def start_func(n: hdag.HistoryDagNode):
+        seqid = n.attr["name"]
+        if seqid in newidmap:
+            return frozendict(
+                {
+                    newisotype(name): len(oldidset)
+                    for name, oldidset in newidmap[seqid].items()
+                }
+            )
         else:
-            isoset = frozenset()
-        return hdag.utils.IntState(0, state=isoset)
+            return frozendict()
 
-    def sumweights(weights: Sequence[Tuple[float, FrozenSet[Isotype]]]):
-        ps = [int(i) for i in weights]
-        ts = [item for i in weights for item in i.state]
+    def sumweights(weights: Sequence[Tuple[float, frozendict]]):
+        ts = [item for i in weights for item in i.keys()]
         if ts:
-            newt = frozenset({min(ts)})
+            return frozendict({min(ts): 0})
         else:
-            newt = frozenset()
-        return hdag.utils.IntState(
-            sum(isotype_distance(list(newt)[0], el) for el in ts) + sum(ps),
-            state=newt,
-        )
+            return frozendict()
 
     return hdag.utils.AddFuncDict(
         {
-            "start_func": lambda n: hdag.utils.IntState(0, state=frozenset()),
-            "edge_weight_func": distance_func,
+            "start_func": start_func,
+            "edge_weight_func": lambda n1, n2: frozendict(),
             "accum_func": sumweights,
         },
-        name="Isotype Pars.",
+        name="Inferred Isotype",
     )

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -459,7 +459,7 @@ def _isotype_annotation_dagfuncs(
 
     if idmap is None:
         if idmap_file is None:
-            raise TypeError("either idmap or idmap_file is required")
+            raise TypeError("either idmap or idmap_file is required for isotyping")
         else:
             with open(idmap_file, "r") as fh:
                 idmap = {}

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         "scipy",
         "seaborn",
         "multiset",
+        "frozendict",
         "historydag"
     ],
 )

--- a/tests/test_isotype.py
+++ b/tests/test_isotype.py
@@ -1,4 +1,4 @@
-from gctree.isotyping import _isotype_dagfuncs
+from gctree.isotyping import _isotype_dagfuncs, _isotype_annotation_dagfuncs
 import gctree.branching_processes as bp
 import gctree.isotyping as iso
 import gctree.phylip_parse as pp
@@ -38,7 +38,7 @@ def test_isotype_disambiguate():
 
 
 def test_trim_byisotype():
-    kwargs = _isotype_dagfuncs(
+    kwargs = _isotype_annotation_dagfuncs(
         isotypemap_file="example/isotypemap.txt",
         idmap_file="tests/example_output/original/idmap.txt",
     )
@@ -47,6 +47,11 @@ def test_trim_byisotype():
     # idmap_file=None,
     # isotype_names=None,
     tdag = dag.copy()
+    tdag.optimal_weight_annotate(**kwargs, optimal_func=lambda l: l[0])
+    for node in tdag.preorder():
+        if node.attr is not None:
+            node.attr["isotype"] = node._dp_data
+    kwargs = _isotype_dagfuncs()
     c = tdag.weight_count(**kwargs)
     key = min(c)
     count = c[key]


### PR DESCRIPTION
Previously, isotype parsimony score was computed dynamically in the DAG, without storing any inferred ancestral isotypes.
This PR changes the way isotype parsimony is computed, to make it more natural to store inferred ancestral isotypes as a tree node attribute.

To do this, we use DAG dynamic programming infrastructure to first compute an inferred ancestral isotype for each node in the history DAG. This is possible because a node's inferred isotype depends only on isotypes of reachable leaves below that node, and is therefore the same in any tree containing that node. Computing the isotype parsimony then becomes as easy as reading isotype changes between tree/DAG nodes.

## Changes:
* Move isotype additions to the `CollapsedForest.add_isotypes` method, which should be called before `CollapsedForest.filter_trees`, if isotype parsimony is to be used for filtering
* Remove isotype-related arguments from `CollapsedForest.filter_trees` method, except for the new argument `ignore_isotypes`, which allows a user to ignore isotype parsimony when filtering a CollapsedForest to which isotype information was already added.
* Pickled trees, as well as trees extracted from a CollapsedForest, will now have a node attribute `isotype`, containing a `frozendict` keyed by `Isotype` objects, with values the observed count of that isotype at that node. For inferred ancestral isotypes on unobserved nodes, the count is 0. If data is missing (for example, if no isotype information was provided) then the frozendict is empty.

## Concerns:
* Should `ignore_isotypes` argument be propagated to the cli?
* ~~As before, no warnings are given when there's missing isotype data. In particular, no warning is given if one calls `filter_trees` on a forest with `ignore_isotype=False` without first calling `add_isotypes` on the forest. Perhaps a check that all DAG nodes have valid isotype information could be made by `filter_trees` whenever `ignore_isotype` is True, and at least a warning given for missing data.~~

## Tests:
* Passes all tests, and runs on real data.
* I verified separately that the new isotype parsimony calculations match old ones