### PR TITLE
Mutability chain split

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1131,7 +1131,7 @@ class CollapsedForest:
             mut_funcs = _mutability_dagfuncs(
                 mutability_file=mutability_file,
                 substitution_file=substitution_file,
-                splits = [] if chain_split is None else [chain_split]
+                splits=[] if chain_split is None else [chain_split],
             )
         else:
             mut_funcs = placeholder_dagfuncs

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1129,7 +1129,9 @@ class CollapsedForest:
                 print("Mutation model parsimony will be used as a ranking criterion")
 
             mut_funcs = _mutability_dagfuncs(
-                mutability_file=mutability_file, substitution_file=substitution_file
+                mutability_file=mutability_file,
+                substitution_file=substitution_file,
+                splits = [] if chain_split is None else [chain_split]
             )
         else:
             mut_funcs = placeholder_dagfuncs

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1060,6 +1060,7 @@ class CollapsedForest:
         mutability_file: str = None,
         substitution_file: str = None,
         ignore_isotype: bool = False,
+        chain_split: int = None,
         verbose: bool = False,
         outbase: str = "gctree.out",
         summarize_forest: bool = False,
@@ -1083,6 +1084,8 @@ class CollapsedForest:
             substitution_file: A substitution model
             ignore_isotype: Ignore isotype parsimony when ranking. By default, isotype information added with
                 :meth:``add_isotypes`` will be used to compute isotype parsimony, which is used in ranking.
+            chain_split: The index at which non-adjacent sequences are concatenated, for calculating
+                mutability parsimony.
             verbose: print information about trimming
             outbase: file name stem for a file with information for each tree in the DAG.
             summarize_forest: whether to write a summary of the forest to file `[outbase].forest_summary.log`

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -211,7 +211,7 @@ def infer(args):
         tree_stats=args.tree_stats,
         mutability_file=args.mutability,
         substitution_file=args.substitution,
-        chain_split=args.chain_split
+        chain_split=args.chain_split,
     )
 
     if args.verbose:

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -211,6 +211,7 @@ def infer(args):
         tree_stats=args.tree_stats,
         mutability_file=args.mutability,
         substitution_file=args.substitution,
+        chain_split=args.chain_split
     )
 
     if args.verbose:

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -537,7 +537,8 @@ def get_parser():
         default=None,
         help=(
             "when using concatenated heavy and light chains, this is the 0-based"
-            " index at which the 2nd chain begins, needed for determining coding frame in both chains"
+            " index at which the 2nd chain begins, needed for determining coding frame in both chains,"
+            " and also to correctly calculate mutability parsimony."
         ),
     )
     parser_infer.add_argument(

--- a/gctree/mutation_model.py
+++ b/gctree/mutation_model.py
@@ -394,7 +394,9 @@ def _sequence_disambiguations(sequence, _accum=""):
     yield _accum
 
 
-def _mutability_dagfuncs(*args, splits: List[int] = [], **kwargs) -> hdag.utils.AddFuncDict:
+def _mutability_dagfuncs(
+    *args, splits: List[int] = [], **kwargs
+) -> hdag.utils.AddFuncDict:
     """Return functions for counting mutability parsimony on the history DAG.
 
     Mutability parsimony of a tree is the sum over all edges in the tree
@@ -438,7 +440,9 @@ def _mutability_dagfuncs(*args, splits: List[int] = [], **kwargs) -> hdag.utils.
     )
 
 
-def _mutability_distance_precursors(mutation_model: MutationModel, splits: List[int] = []):
+def _mutability_distance_precursors(
+    mutation_model: MutationModel, splits: List[int] = []
+):
     chunk_idxs = list(zip([0] + splits, splits + [None]))
     # Caching could be moved to the MutationModel class instead.
     context_model = mutation_model.context_model.copy()
@@ -463,8 +467,8 @@ def _mutability_distance_precursors(mutation_model: MutationModel, splits: List[
     )
 
     def add_ns(seq: str):
-        ns = 'N' * h
-        chunks = [seq[start: end] for start, end in chunk_idxs]
+        ns = "N" * h
+        chunks = [seq[start:end] for start, end in chunk_idxs]
         return ns + ns.join(chunks) + ns
 
     @utils.check_distance_arguments
@@ -514,7 +518,9 @@ def _mutability_distance(mutation_model: MutationModel, splits=[]):
 
     Note that, in particular, this function is not symmetric on its  arguments.
     """
-    mutpairs, sum_minus_logp = _mutability_distance_precursors(mutation_model, splits=splits)
+    mutpairs, sum_minus_logp = _mutability_distance_precursors(
+        mutation_model, splits=splits
+    )
 
     def distance(seq1, seq2):
         return sum_minus_logp(mutpairs(seq1, seq2))


### PR DESCRIPTION
A minor fix to avoid computing mutabilities using 5-mers which contain non-contiguous nucleotides (that is, in situations where `--chain_split` option would be provided).

This will change the computed mutability parsimony score when there are mutations within two bases of the `chain_split` site.