### PR TITLE
Fix multiple tree nodes with same name

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -152,3 +152,12 @@ For example, here is the top ranked tree above, with isotypes added:
 
 .. image:: isotyped/gctree.out.inference.1.p.isotype_parsimony.28.svg
   :width: 1000
+
+A note about node names
+=======================
+
+The names associated with unobserved nodes (for example, in trees rendered with
+`--idlabel`) are arbitrarily chosen, but are guaranteed to correspond
+bijectively with unobserved sequences. However, if gctree output contains
+multiple trees, **two unobserved nodes which share the same name but occur in
+different output trees will not in general possess the same unobserved sequence.**

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1484,6 +1484,16 @@ class CollapsedForest:
                     "Observed nonroot sequences in history DAG tree don't match "
                     "observed nonroot sequences passed in leaf_seqs."
                 )
+            # The maps from nodes to names and nodes to sequences are bijections
+            n_nodes = len(ctree.tree.traverse())
+            n_names = len({node.name for node in ctree.tree.traverse()})
+            n_seqs = len({node.sequence for node in ctree.tree.traverse()})
+            if not (n_nodes == n_names and n_names == n_seqs):
+                raise RuntimeError(
+                    "Multiple sequences with the same name, or multiple"
+                    "names for the same sequence, observed in collapsed tree."
+                )
+
         return ctree
 
     def __repr__(self):
@@ -1667,6 +1677,10 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
         for node in dag.preorder(skip_root=True)
         if node.is_leaf()
     }
+    # add naive sequences, which are children of dagroot
+    leaf_sequence_d.update(
+        {node.label.sequence: node.attr["name"] for node in dag.dagroot.children()}
+    )
     # build dictionary of unique names, preserving leaf names
     name_d = {
         seq: (leaf_sequence_d[seq] if seq in leaf_sequence_d else str(idx))

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1683,6 +1683,8 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
         if node.is_leaf()
     }
     # add naive sequences, which are children of dagroot
+    # If fake root leaves have been added, they'll have the same sequence and
+    # name
     leaf_sequence_d.update(
         {node.label.sequence: node.attr["name"] for node in dag.dagroot.children()}
     )

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1485,9 +1485,14 @@ class CollapsedForest:
                     "observed nonroot sequences passed in leaf_seqs."
                 )
             # The maps from nodes to names and nodes to sequences are bijections
-            n_nodes = len(ctree.tree.traverse())
-            n_names = len({node.name for node in ctree.tree.traverse()})
-            n_seqs = len({node.sequence for node in ctree.tree.traverse()})
+            n_nodes = 0
+            names = set()
+            seqs = set()
+            for node in ctree.tree.traverse():
+                n_nodes += 1
+                names.add(node.name)
+                seqs.add(node.sequence)
+            n_names, n_seqs = len(names), len(seqs)
             if not (n_nodes == n_names and n_names == n_seqs):
                 raise RuntimeError(
                     "Multiple sequences with the same name, or multiple"

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -46,7 +46,10 @@ class CollapsedTree:
         tree: :class:`ete3.TreeNode` object with ``abundance`` node features
 
     Args:
-        tree: ete3 tree with ``abundance`` node features. Nonzero abundances expected on leaves, and optionally nodes adjacent to leaves via a path of length zero edges. If uncollapsed, it will be collapsed along branches with no mutations. Can be ommitted on initializaion, and later simulated.
+        tree: ete3 tree with ``abundance`` node features. Nonzero abundances expected on leaves,
+            and optionally nodes adjacent to leaves via a path of length zero edges. If uncollapsed,
+            it will be collapsed along branches with no mutations. Can be ommitted on initializaion, and later simulated.
+            If a tree is provided, names of nodes with abundance 0 will not be preserved.
         allow_repeats: tolerate the existence of nodes with the same genotype after collapse, e.g. in sister clades.
     """
 
@@ -1691,7 +1694,7 @@ def _make_dag(trees, sequence_counts={}, from_copy=True):
             )
 
     # names on internal nodes are all messed up from disambiguation step, we'll
-    # fix them in _clade_tree_to_ctree.
+    # fix them in CollapsedTree.__init__.
     return dag
 
 


### PR DESCRIPTION
This PR is intended to fix an issue where multiple internal sequences may have the same node name.

It also adds a test in `CollapsedTree._clade_tree_to_ctree` which verifies that for any collapsed tree extracted from the history DAG, the maps from nodes to sequences and sequences to names are bijections.