### PR TITLE
Simplify abundance logic and remove tuple sequence names

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -69,7 +69,7 @@ class CollapsedTree:
                     else:
                         parent_isotype[key] = val
                 return frozendict(parent_isotype)
-
+            
             # remove unobserved internal unifurcations
             for node in self.tree.iter_descendants():
                 if node.abundance == 0 and len(node.children) == 1:
@@ -112,8 +112,8 @@ class CollapsedTree:
                         if len(node.up.name) == 1:
                             node.up.name = node.up.name[0]
                     node.delete(prevent_nondicotomic=False)
-                node.add_feature('inferred_isotype', min(node.isotype.keys()))
-            self.tree.add_feature('inferred_isotype', min(self.tree.isotype.keys()))
+                node.add_feature("inferred_isotype", min(node.isotype.keys(), default=None))
+            self.tree.add_feature("inferred_isotype", min(self.tree.isotype.keys(), default=None))
 
             final_observed_genotypes = set()
             for node in self.tree.traverse():

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1597,7 +1597,11 @@ def _make_dag(trees, from_copy=True):
     leaf_seqs = {get_sequence(node) for node in trees[0].get_leaves()}
 
     # Assume all trees have same observed nodes.
-    sequence_counts = {node.sequence: node.abundance for node in trees[0].traverse() if node.abundance > 0}
+    sequence_counts = {
+        node.sequence: node.abundance
+        for node in trees[0].traverse()
+        if node.abundance > 0
+    }
     if from_copy:
         trees = [tree.copy() for tree in trees]
     if all(len(tree.children) > 1 for tree in trees):

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1431,9 +1431,10 @@ class CollapsedForest:
 
         # Remove dummy leaf added below root for hDAG compatibility
         dummyleaves = [
-            node for node in etetree.children if node.is_leaf() and node.abundance == 0
+            node for node in etetree.children if node.is_leaf() and node.name == ''
         ]
-        assert len(dummyleaves) <= 1
+        if len(dummyleaves) > 1:
+            raise RuntimeError("Multiple temporary leaves found in tree. Does an observed sequence have name ''?")
         for leaf in dummyleaves:
             leaf.delete(prevent_nondicotomic=False)
 

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1431,10 +1431,12 @@ class CollapsedForest:
 
         # Remove dummy leaf added below root for hDAG compatibility
         dummyleaves = [
-            node for node in etetree.children if node.is_leaf() and node.name == ''
+            node for node in etetree.children if node.is_leaf() and node.name == ""
         ]
         if len(dummyleaves) > 1:
-            raise RuntimeError("Multiple temporary leaves found in tree. Does an observed sequence have name ''?")
+            raise RuntimeError(
+                "Multiple temporary leaves found in tree. Does an observed sequence have name ''?"
+            )
         for leaf in dummyleaves:
             leaf.delete(prevent_nondicotomic=False)
 

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -62,11 +62,13 @@ class CollapsedTree:
 
             def merge_isotype_dicts(parent_isotype, child_isotype):
                 # values are abundances and keys are isotypes.
+                parent_isotype = dict(parent_isotype)
                 for key, val in child_isotype:
                     if key in parent_isotype:
                         parent_isotype[key] = max(parent_isotype[key], val)
                     else:
                         parent_isotype[key] = val
+                return frozendict(parent_isotype)
 
             # remove unobserved internal unifurcations
             for node in self.tree.iter_descendants():

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -80,7 +80,9 @@ class CollapsedTree:
                 )
 
             # iterate over the tree below root and collapse edges of zero
-            # length.
+            # length if the node is a leaf and it's parent has nonzero
+            # abundance we combine taxa names to a set to acommodate
+            # bootstrap samples that result in repeated genotypes
             observed_genotypes = set((leaf.name for leaf in self.tree))
             observed_genotypes.add(self.tree.name)
             for node in self.tree.get_descendants(strategy="postorder"):

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -63,7 +63,7 @@ class CollapsedTree:
             def merge_isotype_dicts(parent_isotype, child_isotype):
                 # values are abundances and keys are isotypes.
                 parent_isotype = dict(parent_isotype)
-                for key, val in child_isotype:
+                for key, val in child_isotype.items():
                     if key in parent_isotype:
                         parent_isotype[key] = max(parent_isotype[key], val)
                     else:
@@ -112,6 +112,8 @@ class CollapsedTree:
                         if len(node.up.name) == 1:
                             node.up.name = node.up.name[0]
                     node.delete(prevent_nondicotomic=False)
+                node.add_feature('inferred_isotype', min(node.isotype.keys()))
+            self.tree.add_feature('inferred_isotype', min(self.tree.isotype.keys()))
 
             final_observed_genotypes = set()
             for node in self.tree.traverse():

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -667,7 +667,7 @@ class CollapsedTree:
         Args:
             file_name: file name (.nk suffix recommended)
         """
-        self.tree.write(format=1, outfile=file_name)
+        self.tree.write(format=1, outfile=file_name, format_root_node=True)
 
     def compare(
         self, tree2: CollapsedTree, method: str = "identity"

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -69,7 +69,7 @@ class CollapsedTree:
                     else:
                         parent_isotype[key] = val
                 return frozendict(parent_isotype)
-            
+
             # remove unobserved internal unifurcations
             for node in self.tree.iter_descendants():
                 if node.abundance == 0 and len(node.children) == 1:
@@ -112,8 +112,12 @@ class CollapsedTree:
                         if len(node.up.name) == 1:
                             node.up.name = node.up.name[0]
                     node.delete(prevent_nondicotomic=False)
-                node.add_feature("inferred_isotype", min(node.isotype.keys(), default=None))
-            self.tree.add_feature("inferred_isotype", min(self.tree.isotype.keys(), default=None))
+                node.add_feature(
+                    "inferred_isotype", min(node.isotype.keys(), default=None)
+                )
+            self.tree.add_feature(
+                "inferred_isotype", min(self.tree.isotype.keys(), default=None)
+            )
 
             final_observed_genotypes = set()
             for node in self.tree.traverse():

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -166,7 +166,7 @@ def infer(args):
 
     if len(args.infiles) == 2:
         forest = bp.CollapsedForest(
-            *pp.parse_outfile(args.infiles[0], args.infiles[1], args.root)
+            pp.parse_outfile(args.infiles[0], args.infiles[1], args.root)
         )
         if forest.n_trees == 1:
             warnings.warn("only one parsimony tree reported from dnapars")

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -100,9 +100,7 @@ def parse_seqdict(fh, mode="dnaml"):
 # list biopython.SeqRecords and a dict containing adjacency
 # relationships and distances between nodes.
 def parse_outfile(outfile, abundance_file=None, root="root", disambiguate=False):
-    """parse phylip outfile, and return dnapars trees, a dictionary mapping
-    node names to sequences, and a dictionary mapping node names to observed
-    abundances."""
+    """parse phylip outfile, and return dnapars trees."""
     if abundance_file is not None:
         counts = {
             line.split(",")[0]: int(line.split(",")[1]) for line in open(abundance_file)
@@ -141,11 +139,7 @@ def parse_outfile(outfile, abundance_file=None, root="root", disambiguate=False)
     if disambiguate:
         # Disambiguate sets node.dist for all nodes in disambiguated trees
         trees = [disambiguate(tree) for tree in trees]
-    if counts is None:
-        sequence_counts = None
-    else:
-        sequence_counts = {sequences[name]: count for name, count in counts.items()}
-    return (trees, sequence_counts)
+    return trees
 
 
 def disambiguate(tree: Tree, random_state=None) -> Tree:
@@ -289,7 +283,7 @@ def main(arg_list=None):
     if args.outputfile is None:
         args.outputfile = args.phylip_outfile + ".collapsed_forest.p"
     forest = bp.CollapsedForest(
-        *parse_outfile(args.phylip_outfile, args.abundance_file, args.root)
+        parse_outfile(args.phylip_outfile, args.abundance_file, args.root)
     )
     with open(args.outputfile, "wb") as fh:
         pickle.dump(forest, fh)

--- a/tests/test_isotype.py
+++ b/tests/test_isotype.py
@@ -17,7 +17,7 @@ trees_seqcounts1 = pp.parse_outfile(
     root="GL",
 )
 
-forest = bp.CollapsedForest(*trees_seqcounts1)
+forest = bp.CollapsedForest(trees_seqcounts1)
 dag = forest._forest
 
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -131,6 +131,7 @@ def test_newcounters():
 def test_newlikelihoods():
     """Make sure the likelihoods found by new CollapsedTree.ll agree with old"""
     p, q = 0.4, 0.6
+    ll_dagfuncs = bp._ll_genotype_dagfuncs(p, q)
 
     # new and old trees agree
     for newforest, newforest_ctrees, oldforest in allforests:
@@ -148,6 +149,8 @@ def test_newlikelihoods():
 
             assert ll_isclose(oldfll, newfll)
             assert ll_isclose(oldfll, newfctreell)
+        for dagll, treell in zip(sorted(newforest._forest.weight_count(**ll_dagfuncs).elements()), sorted(ctree.ll(p, q) for ctree in newforest)):
+            assert np.isclose(dagll, treell)
 
 
 def test_fit():

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -30,32 +30,28 @@ def make_oldcforest(newforest):
     )
 
 
-trees_seqcounts1 = pp.parse_outfile(
+trees1 = pp.parse_outfile(
     "tests/example_output/original/small_outfile",
     abundance_file="tests/example_output/original/abundances.csv",
     root="GL",
 )
-# Sample trees
-trees1 = trees_seqcounts1[0]
 # Sample trees disambiguated
 trees1dis = [pp.disambiguate(tree.copy()) for tree in trees1]
-trees_seqcounts2 = pp.parse_outfile(
+trees2 = pp.parse_outfile(
     "tests/example_output/observed_root/small_outfile",
     abundance_file="tests/example_output/observed_root/abundances.csv",
     root="GL",
 )
-# Sample trees with observed root
-trees2 = trees_seqcounts2[0]
 # Sample trees with observed root disambiguated
 trees2dis = [pp.disambiguate(tree.copy()) for tree in trees2]
 
 # Ambiguous and disambiguated, lists of sample trees and their associated counts
-testtrees = [trees_seqcounts1, trees_seqcounts2]
-testtreesdis = [(trees1dis, trees_seqcounts1[1]), (trees2dis, trees_seqcounts2[1])]
+testtrees = [trees1, trees2]
+testtreesdis = [trees1dis, trees2dis]
 
 # The three kinds of CollapsedForests we're comparing:
 # new ones with hDAG
-newforests = [bp.CollapsedForest(*trees_seqcounts) for trees_seqcounts in testtrees]
+newforests = [bp.CollapsedForest(trees) for trees in testtrees]
 
 # new ones with a list of ctrees
 newforests_ctrees = []


### PR DESCRIPTION
* fixes #87  where a pseudo-leaf added for history DAG compatibility is not properly removed, resulting in a root node named `('', naive)` in the final tree
* fixes an issue where the inferred isotype on internal nodes is not properly recorded during collapsing. Each node on the final tree has an `isotype` attribute, containing a dictionary, in which keys are isotypes and values are observed abundances.
* adds a new `inferred_isotype` attribute to nodes in the final collapsed tree, which is the isotype inferred for the ancestral cell(s) with the offspring claimed to belong to that node in the tree. There should be no illegal transitions between `inferred_isotype`'s along edges in the tree.
* uses the `format_root_node` argument for `ete3.Tree.write`, so that the root node name is included in the newick file output by `CollapsedTree.newick`.
* simplifies the sharing of abundance data internally in gctree.