### PR TITLE
71 ambiguous input data

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -161,3 +161,48 @@ The names associated with unobserved nodes (for example, in trees rendered with
 bijectively with unobserved sequences. However, if gctree output contains
 multiple trees, **two unobserved nodes which share the same name but occur in
 different output trees will not in general possess the same unobserved sequence.**
+
+A note about ambiguous sequence data
+====================================
+
+Gctree can handle input sequences which contain ambiguous bases, but handling
+of such sequences is experimental. That is, there may be issues with both the
+implementation and the underlying methods.
+
+If you use gctree to build trees from ambiguous sequence data, it's probably a good idea
+to follow at least these guidelines:
+
+* Make sure that all sites are unambiguous in at least one of the input
+  sequences. If a site contains an ambiguous base in all input sequences,
+  gctree will choose an arbitrary base for that site. The bases chosen for such
+  sites should not be interpreted as meaningful in any way.
+* Understand that for any observed sequence disambiguated by gctree, another choice of
+  disambiguation for that sequence may exist, which results in a better tree
+  with respect to the ranking criteria. The only guarantee is that
+  disambiguations of observed sequences are maximally parsimonious given the
+  tree topology in which they appear.
+
+Gctree can handle ambiguous input sequences because ``dnapars`` can accept
+ambiguous input sequences. Each tree output by ``dnapars`` is then
+disambiguated. It is possible that multiple observed sequences may be
+disambiguated in identical ways, in which case their corresponding leaf nodes,
+and abundances, are merged. The deduplicated sequence ids corresponding to each
+node in the final tree output by gctree are retained in the ``original_ids`` node
+attribute.
+
+Here's a bit more discussion about how much the disambiguated observed
+sequences can be trusted:
+
+**Why not to trust leaf disambiguation:**
+
+As mentioned above, if the same site(s) contain ambiguous bases in all sequences, the disambiguation is completely arbitrary at those sites, but could be mistakenly interpreted as informed.
+Also alluded to above, if multiple possible disambiguated leaf sequences exist for a particular dnapars topology, one will be chosen arbitrarily, even though another may be more plausible IRL, or with respect to the ranking criteria that gctree uses.
+
+**Why to trust leaf disambiguation:**
+
+Disambiguation is informed by sequence placement in the tree (by dnapars), which takes into account all that is known about the sequences.
+Disambiguation minimizes parsimony score, meaning that
+ambiguous sites will be filled in using bases in the most closely related
+sequence in which those sites are unambiguous.
+
+Also, different trees, with possibly different disambiguated leaf sequences, are ranked according to all data (isotype, abundance, mutability) provided to gctree, and the disambiguated leaf sequences influence that ranking. This means that ranking may influence the chosen disambiguation of observed sequences to be more plausible.

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1640,12 +1640,11 @@ def _make_dag(trees, from_copy=True):
     # add pseudo-leaf below root in all trees:
     # This is done first in case root is ambiguous, and gets merged with
     # another ambiguous leaf node after disambiguation.
-    rootname = trees[0].name   # all root nodes must have the same name
+    rootname = trees[0].name  # all root nodes must have the same name
     for tree in trees:
         newleaf = tree.add_child(name=tree.name, dist=0)
         newleaf.add_feature("sequence", tree.sequence)
         newleaf.add_feature("abundance", tree.abundance)
-
 
     if any(_is_ambiguous(leaf.sequence) for leaf in trees[0].iter_leaves()):
         warnings.warn(

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -93,10 +93,12 @@ class CollapsedTree:
                     node.up.abundance = max(node.abundance, node.up.abundance)
                     # isotype is dictionary with isotype as key and observed
                     # abundance as value
-                    node.up.isotype = merge_isotype_dicts(node.up.isotype, node.isotype)
+                    if "isotype" in node.features:
+                        node.up.isotype = merge_isotype_dicts(node.up.isotype, node.isotype)
                     # original_ids is a set of observed ids corresponding to
                     # each node
-                    node.up.original_ids = node.original_ids | node.up.original_ids
+                    if "original_ids" in node.features:
+                        node.up.original_ids = node.original_ids | node.up.original_ids
                     if isinstance(node.name, str):
                         node_set = set([node.name])
                     else:
@@ -115,12 +117,15 @@ class CollapsedTree:
                         if len(node.up.name) == 1:
                             node.up.name = node.up.name[0]
                     node.delete(prevent_nondicotomic=False)
-                node.add_feature(
-                    "inferred_isotype", min(node.isotype.keys(), default=None)
+
+                if "isotype" in node.features:
+                    node.add_feature(
+                        "inferred_isotype", min(node.isotype.keys(), default=None)
+                    )
+            if "isotype" in node.features:
+                self.tree.add_feature(
+                    "inferred_isotype", min(self.tree.isotype.keys(), default=None)
                 )
-            self.tree.add_feature(
-                "inferred_isotype", min(self.tree.isotype.keys(), default=None)
-            )
 
             final_observed_genotypes = set()
             for node in self.tree.traverse():

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1762,14 +1762,10 @@ def _make_dag(trees, from_copy=True):
         if node.is_leaf():
             for parent in node.parents:
                 if parent.label.sequence == node.label.sequence:
-                    parent.attr["abundance"] = node.label.abundance
-                    parent.attr["_leaf_equivalent"] = True
-        if "abundance" not in node.attr:
-            node.attr["abundance"] = node.label.abundance
-        if "_leaf_equivalent" not in node.attr:
-            node.attr["_leaf_equivalent"] = False
-    dag.dagroot.attr["_leaf_equivalent"] = False
+                    parent.label = node.label
 
+    for node in dag.preorder(skip_root=True):
+        node.attr["abundance"] = node.label.abundance
 
     if len(dag.hamming_parsimony_count()) > 1:
         raise RuntimeError(
@@ -1793,7 +1789,7 @@ def _cmcounter_dagfuncs():
             return multiset.FrozenMultiset()
         else:
             m = len(n2.clades)
-            if n2.attr["_leaf_equivalent"]:
+            if frozenset({n2.label}) in n2.clades:
                 m -= 1
             return multiset.FrozenMultiset([(n2.attr["abundance"], m)])
 
@@ -1843,7 +1839,7 @@ def _ll_genotype_dagfuncs(p: np.float64, q: np.float64) -> hdag.utils.AddFuncDic
         Expects DAG to have abundances added so that each node has
         "abundance" key in attr dict.
         """
-        if n2.is_leaf() and n2.label == n1.label:
+        if n2.is_leaf() and n2.label.sequence == n1.label.sequence:
             return hdag.utils.FloatState(0.0, state=Decimal(0.0))
         else:
             m = len(n2.clades)

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -94,7 +94,9 @@ class CollapsedTree:
                     # isotype is dictionary with isotype as key and observed
                     # abundance as value
                     if "isotype" in node.features:
-                        node.up.isotype = merge_isotype_dicts(node.up.isotype, node.isotype)
+                        node.up.isotype = merge_isotype_dicts(
+                            node.up.isotype, node.isotype
+                        )
                     # original_ids is a set of observed ids corresponding to
                     # each node
                     if "original_ids" in node.features:

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -46,9 +46,9 @@ class CollapsedTree:
         tree: :class:`ete3.TreeNode` object with ``abundance`` node features
 
     Args:
-        tree: ete3 tree with ``abundance`` node features. Nonzero abundances expected on leaves,
-            and optionally nodes adjacent to leaves via a path of length zero edges. If uncollapsed,
-            it will be collapsed along branches with no mutations. Can be ommitted on initializaion, and later simulated.
+        tree: ete3 tree with ``abundance`` node features. If uncollapsed,
+            it will be collapsed along branches with no mutations.
+            Can be ommitted on initializaion, and later simulated.
             If a tree is provided, names of nodes with abundance 0 will not be preserved.
         allow_repeats: tolerate the existence of nodes with the same genotype after collapse, e.g. in sister clades.
     """
@@ -85,7 +85,9 @@ class CollapsedTree:
             # length if the node is a leaf and it's parent has nonzero
             # abundance we combine taxa names to a set to acommodate
             # bootstrap samples that result in repeated genotypes
-            observed_genotypes = set((leaf.name for leaf in self.tree))
+            observed_genotypes = set(
+                node.name for node in self.tree.traverse() if node.abundance
+            )
             observed_genotypes.add(self.tree.name)
             for node in self.tree.get_descendants(strategy="postorder"):
                 if node.dist == 0:

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1522,11 +1522,15 @@ class CollapsedForest:
                     "History DAG tree parsimony score does not match parsimony score provided"
                 )
             # Root sequence is a possible disambiguation of root:
-            if any(base not in gctree.utils.ambiguous_dna_values[ambig_base]
-                   for base, ambig_base in zip(ctree.tree.sequence, self._validation_stats["root_seq"])):
+            if any(
+                base not in gctree.utils.ambiguous_dna_values[ambig_base]
+                for base, ambig_base in zip(
+                    ctree.tree.sequence, self._validation_stats["root_seq"]
+                )
+            ):
                 raise RuntimeError(
                     "History DAG root node sequence does not match root sequence provided\n"
-                    "found: " + ctree.tree.sequence + '\n'
+                    "found: " + ctree.tree.sequence + "\n"
                     "expected: " + self._validation_stats["root_seq"]
                 )
             # Leaf names:
@@ -1752,6 +1756,7 @@ def _make_dag(trees, from_copy=True):
                 return False
         except OverflowError:
             return True
+
     if test_explode_individually():
         warnings.warn(
             "Parsimony trees have too many ambiguities for disambiguation in all possible ways. "

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1668,9 +1668,6 @@ def _make_dag(trees, from_copy=True):
             " disambiguated leaf sequences may be possible."
         )
         for tree in trees:
-            print("NEW TREE:")
-            with open("curr_tree.p", "wb") as fh:
-                fh.write(pickle.dumps(tree))
             for node in tree.iter_leaves():
                 node.add_feature("original_ids", {node.name})
             disambig_tree = tree.copy()
@@ -1679,8 +1676,6 @@ def _make_dag(trees, from_copy=True):
                 for d_node, o_node in zip(disambig_tree.traverse(), tree.traverse())
             }
             disambiguate(disambig_tree)
-            with open("curr_disambig_tree.p", "wb") as fh:
-                fh.write(pickle.dumps(disambig_tree))
 
             # remove duplicate leaves, and adjust abundances
             leaf_seqs = {}
@@ -1690,7 +1685,6 @@ def _make_dag(trees, from_copy=True):
                     leaf_seqs[leaf.sequence].append(leaf)
                 else:
                     leaf_seqs[leaf.sequence] = [leaf]
-            print(leaf_seqs)
             for sequence, leaf_list in leaf_seqs.items():
                 if len(leaf_list) > 1:
                     # Always choose root pseudo-leaf to represent nodes, if
@@ -1707,7 +1701,6 @@ def _make_dag(trees, from_copy=True):
                         seq_id for node in leaf_list for seq_id in node.original_ids
                     }
                     while to_delete:
-                        print(to_delete)
                         for node in to_delete:
                             node_map[node].delete(prevent_nondicotomic=False)
                             node.delete(prevent_nondicotomic=False)

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1144,10 +1144,11 @@ class CollapsedForest:
             if verbose:
                 print("Isotype parsimony will be used as a ranking criterion")
             # Check for missing isotype data in all but root node, and fake root-adjacent leaf node
+            rootname = list(self._forest.dagroot.children())[0].attr["name"]
             if any(
                 not node.attr["isotype"]
                 for node in self._forest.preorder()
-                if not node.is_root() and node.attr["name"] != ""
+                if not node.is_root() and node.attr["name"] != rootname
             ):
                 warnings.warn(
                     "Some isotype data seems to be missing. Isotype parsimony scores may be incorrect."
@@ -1441,6 +1442,8 @@ class CollapsedForest:
         # collapsing takes care of all uncollapsed leaves. This works for
         # observed root because all trees have added pseudo leaf with root name
         # and abundance.
+        # original_ids is a set of original leaf node ids, or empty if node is
+        # not a leaf.
         etetree = clade_tree.to_ete(
             name_func=lambda n: n.attr["name"],
             features=["sequence"],
@@ -1716,9 +1719,6 @@ def _make_dag(trees, from_copy=True):
         # be annotated on root, not a separate leaf.
 
     def trees_to_dag(trees):
-        # abundance will only be nonzero on leaf node labels, but will be in attributes
-        # of all nodes? Can we name pseudo leaf the same as root, but leave
-        # root abundance 0 and have gctree collapsing take care of it all?
         return hdag.history_dag_from_etes(
             trees,
             ["sequence"],

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -475,6 +475,18 @@ def _isotype_annotation_dagfuncs(
 
     def start_func(n: hdag.HistoryDagNode):
         seqid = n.attr["name"]
+        iso_dict = {}
+        for seqid in n.attr["original_ids"]:
+            if seqid in newidmap:
+                for key, val in newidmap[seqid].items():
+                    isotype = newisotype(key)
+                    if isotype in iso_dict:
+                        iso_dict[isotype] = iso_dict[isotype] + len(val)
+                    else:
+                        iso_dict[isotype] = len(val)
+        # if this isn't a leaf, original_ids is empty and the returned dict
+        # will be empty.
+        return frozendict(iso_dict)
         if seqid in newidmap:
             return frozendict(
                 {

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -123,7 +123,7 @@ class Isotype:
 
     def iso_string(self) -> str:
         if self.isotype is None:
-            return '?'
+            return "?"
         else:
             return self.order[self.isotype]
 

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -121,14 +121,20 @@ class Isotype:
     def isbefore(self, t: "Isotype") -> bool:
         return self.isotype <= t.isotype
 
+    def iso_string(self) -> str:
+        if self.isotype is None:
+            return '?'
+        else:
+            return self.order[self.isotype]
+
     def __repr__(self) -> str:
-        return f"Isotype('{self.order[self.isotype]}')"
+        return f"Isotype('{self.iso_string()}')"
 
     def __str__(self) -> str:
-        return f"{self.order[self.isotype]}"
+        return self.iso_string()
 
     def copy(self) -> "Isotype":
-        return Isotype(self.order, self.weight_matrix, self.order[self.isotype])
+        return Isotype(self.order, self.weight_matrix, self.iso_string())
 
     @_assert_switching_order_match
     def __eq__(self, other: "Isotype") -> bool:
@@ -136,11 +142,21 @@ class Isotype:
 
     @_assert_switching_order_match
     def __lt__(self, other: "Isotype") -> bool:
-        return self.isotype < other.isotype
+        if other.isotype is None:
+            return True
+        elif self.isotype is None:
+            return False
+        else:
+            return self.isotype < other.isotype
 
     @_assert_switching_order_match
     def __gt__(self, other: "Isotype") -> bool:
-        return self.isotype > other.isotype
+        if other.isotype is None:
+            return False
+        elif self.isotype is None:
+            return True
+        else:
+            return self.isotype > other.isotype
 
     def __hash__(self) -> int:
         return hash(self.__repr__())
@@ -215,7 +231,10 @@ def isotype_distance(t1: Isotype, t2: Isotype) -> float:
     This function is not symmetric on its arguments, so isn't a true
     distance.
     """
-    return t1.weight_matrix[t1.isotype][t2.isotype]
+    if t1.isotype is None or t2.isotype is None:
+        return 0
+    else:
+        return t1.weight_matrix[t1.isotype][t2.isotype]
 
 
 def isotype_parsimony(tree: ete3.TreeNode) -> float:

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,10 +1,15 @@
 r"""Utility functions."""
-from functools import wraps
+from functools import wraps, reduce
 import Bio.Data.IUPACData
+import operator
+from typing import Sequence, Any
+
+Multiplicable = Any
 
 bases = "AGCT-"
 ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
+ambiguous_dna_keys = {frozenset(val): key for key, val in ambiguous_dna_values.items()}
 
 
 def _check_distance_arguments(distance):
@@ -28,3 +33,6 @@ def hamming_distance(seq1: str, seq2: str) -> int:
         seq2: sequence 2
     """
     return sum(x != y for x, y in zip(seq1, seq2))
+
+def product(factors: Sequence[Multiplicable], f=operator.mul, identity=1) -> Multiplicable:
+    return reduce(f, factors, identity)

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -34,5 +34,8 @@ def hamming_distance(seq1: str, seq2: str) -> int:
     """
     return sum(x != y for x, y in zip(seq1, seq2))
 
-def product(factors: Sequence[Multiplicable], f=operator.mul, identity=1) -> Multiplicable:
+
+def product(
+    factors: Sequence[Multiplicable], f=operator.mul, identity=1
+) -> Multiplicable:
     return reduce(f, factors, identity)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setuptools.setup(
         "seaborn",
         "multiset",
         "frozendict",
-        "historydag"
+        "historydag>=1"
     ],
 )

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -12,7 +12,7 @@ def make_oldctree(tree):
     etetree = tree.to_ete(
         name_func=lambda n: n.attr["name"],
         features=["sequence"],
-        feature_funcs={"abundance": lambda n: n.attr["abundance"]},
+        feature_funcs={"abundance": lambda n: n.label.abundance},
     )
     for node in etetree.traverse():
         if not node.is_leaf():


### PR DESCRIPTION
Addresses #71, allowing ambiguous observed sequences to be used as gctree input.

First, while earlier versions of gctree _may_ have accepted ambiguous sequences as input without crashing, I can now be quite sure that the inference result was, in general, not meaningful.

This is a challenge, since when given a set of ambiguous sequences, it's not even clear which correspond to the same "true" sequence.

Here's the approach I've taken:
1. observed sequences are deduplicated as before. That is, two sequences are considered the same iff they are the same, as string literals.
2. deduplicated sequences are fed as-is (containing ambiguities) to `dnapars`.
3. for each ambiguous tree output by dnapars, a single MP disambiguation is chosen arbitrarily. If multiple leaves end up with the same disambiguation, they are merged by collapse so that only one representative is left as a leaf. All leaves are given a `original_ids` attribute containing the (deduplicated) sequence ids merged into that leaf. Abundances of merged leaves are summed. All tree modifications are mirrored on the original (ambiguous) tree, and *finally* the disambiguated leaf sequences are transplanted back into the ambiguous tree. We now have ambiguous dnapars trees whose leaves are unambiguous, and which each accept at least one MP disambiguation.
4. As before, we use the history DAG to disambiguate internal nodes in all possible ways. However, we now include node abundances in DAG node leaf labels, to differentiate between leaves on different trees which may possibly have the same sequence but different merged abundances (as a result of step 3). Internal node labels all have abundance 0 so that collapsing works correctly.
5. Once the history DAG is collapsed, all internal edges are between nodes with different sequences. Now we put correct abundances on leaf-adjacent nodes which have the same sequence as one of their leaf children. This allows dynamic programming methods that calculate likelihood, etc. to correctly predict which leaf-adjacent edges will be collapsed, and makes abundance visible to edges above observed internal nodes.
6. Ranking occurs as before in the history DAG, and CollapsedTrees are extracted. CollapsedTree nodes retain `original_ids` attributes.

# Other changes:
* isotype calculations now use `original_ids` instead of `name` in order to correctly accumulate all the observed isotypes corresponding to a node.

# What's left to do:
* translate the test cases I've been using into some portable tests
* in a future PR allow `phylip_pars.disambiguate` to accept a supplemental weight (e.g. mutability parsimony)
* update documentation with the most relevant bits from this PR description
* *requires a new `historydag` release* which accommodates trees with different sets of leaf labels. This is done, but needs to be released.

# Why not to trust leaf disambiguation:
* Of course, if the same site(s) contain ambiguous bases in all sequences, the disambiguation is completely arbitrary at those sites, but could be mistakenly interpreted as informed.
* If multiple possible disambiguated leaf sequences exist for a particular `dnapars` topology, one will be chosen *arbitrarily*, even though another may be more plausible IRL, or with respect to the ranking criteria that gctree uses.

# Why to trust leaf disambiguation:
* It's informed by sequence placement in the tree (by `dnapars`), which takes into account all that _is_ known about the sequences.
* Different trees, with possibly different disambiguated leaf sequences, are ranked according to all data (isotype, abundance, mutability) provided to gctree, and the disambiguated leaf sequences influence that ranking.