### PR TITLE
Fix numpy errors on gctree import

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -35,8 +35,6 @@ import matplotlib.pyplot as plt
 from typing import Tuple, Dict, List, Union, Set, Callable, Mapping, Sequence
 from decimal import Decimal
 
-np.seterr(all="raise")
-
 
 class CollapsedTree:
     r"""A collapsed tree, modeled as an infinite type Galton-Watson process run
@@ -360,6 +358,7 @@ class CollapsedTree:
 
         return (logf_result, np.array([dlogfdp_result, dlogfdq_result]))
 
+    @np.errstate(all="raise")
     def ll(
         self,
         p: np.float64,
@@ -840,6 +839,7 @@ class CollapsedTree:
                     compatibility_ += weights[i] if weights is not None else 1
             node.support = compatibility_ if compatibility else support
 
+    @np.errstate(all="raise")
     def local_branching(self, tau=1, tau0=0.1):
         r"""Add local branching statistics (Neher et al. 2014) as tree node
         features to the ETE tree attribute.
@@ -976,6 +976,7 @@ class CollapsedForest:
             coll.Counter([tree._cm_counts for tree in self._ctrees]).items()
         )
 
+    @np.errstate(all="raise")
     def ll(
         self,
         p: np.float64,

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -180,8 +180,9 @@ def test_validate_ll_genotype():
         for c in range(c_max):
             for m in range(m_max):
                 if c > 0 or m > 1:
-                    true_res = OldCollapsedTree._ll_genotype(c, m, *params)
-                    res = bp.CollapsedTree._ll_genotype(c, m, *params)
+                    with np.errstate(all='raise'):
+                        true_res = OldCollapsedTree._ll_genotype(c, m, *params)
+                        res = bp.CollapsedTree._ll_genotype(c, m, *params)
                     assert np.isclose(true_res[0], res[0])
                     assert np.isclose(true_res[1][0], res[1][0])
                     assert np.isclose(true_res[1][1], res[1][1])
@@ -192,4 +193,5 @@ def test_recursion_depth():
     recursion depth issues"""
     bp.CollapsedTree._ll_genotype.cache_clear()
     bp.CollapsedTree._max_ll_cache = {}
-    bp.CollapsedTree._ll_genotype(2, 500, 0.4, 0.6)
+    with np.errstate(all='raise'):
+        bp.CollapsedTree._ll_genotype(2, 500, 0.4, 0.6)


### PR DESCRIPTION
This PR fixes #92, and replaces a call to `numpy.seterr`, which changes the error handling behavior of numpy globally whenever gctree is imported, with appropriate calls to the `numpy.errstate` context manager.

There are two strategies for wrapping all numerically sensitive code in a `numpy.errstate` context. One option is to wrap specifically the numpy-calling code blocks in a `with` block, in each function where such code blocks exist. The other option is to wrap larger chunks of code, e.g. entire functions, using `numpy.errstate` as a decorator.

I chose the second option, since the first involves possibly orders of magnitude more invocations of `numpy.errstate` (e.g. every call to `_ll_genotype`). *The policy will be that each public function or method which contains numerically sensitive computations shall be decorated with `numpy.errstate(all='raise')`, or if appropriate use a `with` block.

This approach has two disadvantages:
* In the case of nested function/method calls, it may be difficult to trace which code is executed in the appropriate numpy context
* There may be nested calls to `numpy.errstate`, where decorated functions call other decorated functions.

I think both of these are acceptable.

### Testing:
Exactly which methods are decorated may need to be tweaked. To test, I sprinkled `assert set(numpy.geterr().values()) == {'raise'}` in appropriate places in `gctree.branching_processes`, and ran all tests and pipelines.