### PR TITLE
Make gctree deterministic when ranking is degenerate

### DIFF
--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -156,6 +156,12 @@ def test(args):
 
 def infer(args):
     """inference subprogram."""
+    if args.seed is None:
+        seed = 1
+    else:
+        seed = args.seed
+    random.seed(a=seed)
+    numpy.random.seed(a=seed)
 
     def isotype_add(forest):
         forest.add_isotypes(
@@ -684,9 +690,6 @@ def get_parser():
         " leaves",
     )
     parser_sim.add_argument(
-        "--seed", type=int, default=None, help="integer random seed"
-    )
-    parser_sim.add_argument(
         "--target_dist",
         type=int,
         default=10,
@@ -703,6 +706,9 @@ def get_parser():
 
     # shared parameters
     for subparser in [parser_test, parser_infer, parser_sim]:
+        subparser.add_argument(
+            "--seed", type=int, default=None, help="integer random seed"
+        )
         subparser.add_argument(
             "--outbase", type=str, default="gctree.out", help="output file base name"
         )

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -161,7 +161,7 @@ def infer(args):
     else:
         seed = args.seed
     random.seed(a=seed)
-    numpy.random.seed(a=seed)
+    np.random.seed(a=seed)
 
     def isotype_add(forest):
         forest.add_isotypes(


### PR DESCRIPTION
Adds a `--seed` argument to the inference cli, and fixes an issue where inference results could be nondeterministic with degenerate ranking criteria.