### PR TITLE
Dependency and warning fix and compatibility with Scipy 1.12

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -266,9 +266,9 @@ class CollapsedTree:
     def _ll_genotype(
         c: int, m: int, p: np.float64, q: np.float64
     ) -> Tuple[np.float64, np.ndarray]:
-        r"""Log-probability of getting :math:`c` leaves that are clones of the root and
-        :math:`m` mutant clades off the root lineage, given branching probability :math:`p` and
-        mutation probability :math:`q`.
+        r"""Log-probability of getting :math:`c` leaves that are clones of the
+        root and :math:`m` mutant clades off the root lineage, given branching
+        probability :math:`p` and mutation probability :math:`q`.
 
         AKA the spaceship distribution. Also returns gradient wrt p and q
         (p, q). Computed by dynamic programming.

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1821,9 +1821,11 @@ def _make_dag(trees, from_copy=True, quick_sankoff=False):
                 if parent.label.sequence == node.label.sequence:
                     parent.label = node.label
 
-    if len(dag.hamming_parsimony_count()) > 1:
+    dag = hdag.sequence_dag.SequenceHistoryDag.from_history_dag(dag)
+    pars_count = dag.hamming_parsimony_count()
+    if len(pars_count) > 1:
         raise RuntimeError(
-            f"History DAG parsimony search resulted in parsimony trees of unexpected weights:\n {dag.hamming_parsimony_count()}"
+            f"History DAG parsimony search resulted in parsimony trees of unexpected weights:\n {pars_count}"
         )
 
     # names on internal nodes are all messed up from disambiguation step, we'll

--- a/gctree/mutation_model.py
+++ b/gctree/mutation_model.py
@@ -6,7 +6,6 @@ from ete3 import TreeNode
 import numpy as np
 from scipy.stats import poisson
 import random
-import scipy
 from Bio.Seq import Seq
 import historydag as hdag
 from multiset import FrozenMultiset
@@ -134,7 +133,7 @@ class MutationModel:
             *[self.context_model[x] for x in MutationModel._disambiguate(kmer)]
         )
 
-        average_mutability = scipy.mean(mutabilities_to_average)
+        average_mutability = np.mean(mutabilities_to_average)
         average_substitution = {
             b: sum(
                 substitution_dict[b] for substitution_dict in substitutions_to_average
@@ -193,7 +192,7 @@ class MutationModel:
         # number of mutations m
         trials = 20
         for trial in range(1, trials + 1):
-            m = scipy.random.poisson(lambda_sequence)
+            m = np.random.poisson(lambda_sequence)
             if m <= sequence_length or self.with_replacement:
                 break
             if trial == trials:
@@ -205,17 +204,17 @@ class MutationModel:
         for i in range(m):
             sequence_list = list(sequence)  # make string a list so we can modify it
             # Determine the position to mutate from the mutability matrix
-            mutability_p = scipy.array(
+            mutability_p = np.array(
                 [mutabilities[pos][0] for pos in unmutated_positions]
             )
             for trial in range(1, trials + 1):
-                mut_pos = scipy.random.choice(
+                mut_pos = np.random.choice(
                     unmutated_positions, p=mutability_p / mutability_p.sum()
                 )
                 # Now draw the target nucleotide using the substitution matrix
                 substitution_p = [mutabilities[mut_pos][1][n] for n in "ACGT"]
                 assert 0 <= abs(sum(substitution_p) - 1.0) < 1e-10
-                chosen_target = scipy.random.choice(4, p=substitution_p)
+                chosen_target = np.random.choice(4, p=substitution_p)
                 original_base = sequence_list[mut_pos]
                 sequence_list[mut_pos] = "ACGT"[chosen_target]
                 sequence = "".join(sequence_list)  # reconstruct our sequence

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -111,7 +111,7 @@ def parse_outfile(outfile, abundance_file=None, root="root", disambiguate=False)
     bootstrap = False
     # Ugg... for compilation need to let python know that these will definely both be defined :-/
     sequences, parents = {}, {}
-    with open(outfile, "rU") as fh:
+    with open(outfile, "r") as fh:
         for sect in sections(fh):
             if sect == "parents":
                 parents = {child: parent for child, parent in iter_edges(fh)}

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setuptools.setup(
         "seaborn",
         "multiset",
         "frozendict",
-        "historydag>=1"
+        "historydag>=1.2.0"
     ],
 )


### PR DESCRIPTION
* Fixes #121 (Thanks Jared!)
* Fixes a warning about a deprecated method call in historydag
* Scipy <1.12 re-exported some numpy modules and functions, which were called in various places. Scipy 1.12 no longer re-exports these names, resulting in import errors. This is fixed, and we now call numpy methods directly when we mean to.