### PR TITLE
Fix ufunc attribute error from numpy.log

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,26 +31,6 @@ jobs:
           auto-activate-base: false
           auto-update-conda: true
 
-      - name: Lint
-        # NOTE: must specify the shell so that conda init updates bashrc see:
-        #      https://github.com/conda-incubator/setup-miniconda#IMPORTANT
-        shell: bash -l {0}
-        run: make lint
-
-      - name: Check format with black
-        shell: bash -l {0}
-        run: black --check gctree
-
       - name: Test
         shell: bash -l {0}
         run: make test
-
-      - name: Test docs build
-        # NOTE: only run on ubuntu-latest to save on compute usage
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash -l {0}
-        run: |
-          make docs
-        env:
-          QT_QPA_PLATFORM: offscreen
-          MPLBACKEND: agg

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -1,0 +1,46 @@
+name: build and test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  format-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Install miniconda and create environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: gctree
+          environment-file: environment.yml
+          python-version: "3.10"
+          auto-activate-base: false
+          auto-update-conda: true
+
+      - name: Lint
+        # NOTE: must specify the shell so that conda init updates bashrc see:
+        #      https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+        shell: bash -l {0}
+        run: make lint
+
+      - name: Check format with black
+        shell: bash -l {0}
+        run: black --check gctree
+
+      - name: Test docs build
+        # NOTE: only run on ubuntu-latest to save on compute usage
+        shell: bash -l {0}
+        run: |
+          make docs
+        env:
+          QT_QPA_PLATFORM: offscreen
+          MPLBACKEND: agg

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -1,4 +1,4 @@
-name: build and test
+name: format and lint
 
 on:
   push:

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -32,6 +32,7 @@ import matplotlib as mp
 import matplotlib.pyplot as plt
 from typing import Tuple, Dict, List, Union, Set, Callable, Mapping, Sequence, Optional
 from decimal import Decimal
+import math
 
 sequence_resolutions = hdag.parsimony_utils.standard_nt_ambiguity_map_gap_as_char.get_sequence_resolution_func(
     "sequence"
@@ -1100,7 +1101,9 @@ class CollapsedForest:
                     )
                 grad_l.append(grad_ls[i_prime, j] + res)
             # count_ls shouldn't have any zeros in it...
-            return (-np.log(count_ls.sum()) + scs.logsumexp(ls, b=count_ls)), np.array(
+            # using math.log instead of np.log is essential because np.log
+            # doesn't work on large integers > 2**64 :eyeroll:
+            return (-math.log(count_ls.sum()) + scs.logsumexp(ls, b=count_ls)), np.array(
                 grad_l
             )
         else:

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -1103,9 +1103,9 @@ class CollapsedForest:
             # count_ls shouldn't have any zeros in it...
             # using math.log instead of np.log is essential because np.log
             # doesn't work on large integers > 2**64 :eyeroll:
-            return (-math.log(count_ls.sum()) + scs.logsumexp(ls, b=count_ls)), np.array(
-                grad_l
-            )
+            return (
+                -math.log(count_ls.sum()) + scs.logsumexp(ls, b=count_ls)
+            ), np.array(grad_l)
         else:
             return (ls * count_ls).sum(), np.array(
                 [(grad_ls[:, 0] * count_ls).sum(), (grad_ls[:, 1] * count_ls).sum()]

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -491,9 +491,11 @@ class CollapsedTree:
                     C = ete3.CircleFace(
                         radius=node_size2,
                         color=circle_color,
-                        label={"text": str(node.abundance), "color": text_color}
-                        if node.abundance > 0
-                        else None,
+                        label=(
+                            {"text": str(node.abundance), "color": text_color}
+                            if node.abundance > 0
+                            else None
+                        ),
                     )
                     C.rotation = -90
                     C.hz_align = 1
@@ -610,9 +612,11 @@ class CollapsedTree:
                                     node.add_face(
                                         T,
                                         0,
-                                        position="branch-bottom"
-                                        if start == 0
-                                        else "branch-top",
+                                        position=(
+                                            "branch-bottom"
+                                            if start == 0
+                                            else "branch-top"
+                                        ),
                                     )
                                 if "*" in aa:
                                     nstyle["hz_line_color"] = "red"
@@ -892,9 +896,9 @@ class CollapsedTree:
         for node in self.tree.traverse(strategy="postorder"):
             if node.is_leaf():
                 node.LB_down = {
-                    node: node.abundance * clone_contribution
-                    if node.abundance > 1
-                    else 0
+                    node: (
+                        node.abundance * clone_contribution if node.abundance > 1 else 0
+                    )
                 }
             else:
                 node.LB_down = {node: node.abundance * clone_contribution}
@@ -1772,9 +1776,7 @@ def _make_dag(trees, from_copy=True, quick_sankoff=False):
                 "original_ids": (
                     n.original_ids
                     if "original_ids" in n.features
-                    else {n.name}
-                    if n.is_leaf()
-                    else set()
+                    else {n.name} if n.is_leaf() else set()
                 ),
                 "isotype": frozendict(),
             },

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -173,6 +173,7 @@ def infer(args):
 
         if args.verbose:
             print("number of trees with integer branch lengths:", forest.n_trees)
+
         forest.mle(marginal=True)
         # Add isotypes to forest
         if args.isotype_mapfile:

--- a/gctree/deduplicate.py
+++ b/gctree/deduplicate.py
@@ -58,9 +58,9 @@ def fasta_parse(aln_file, root, frame=None, aln_file2=None, id_abundances=False)
         if seq.id == root:
             root_seq = seqstr
             if seqstr not in seqs_unique_counts:
-                seqs_unique_counts[
-                    seqstr
-                ] = []  # no observed root unless we see it elsewhere
+                seqs_unique_counts[seqstr] = (
+                    []
+                )  # no observed root unless we see it elsewhere
         elif seq.id.isdigit() and id_abundances:
             seqs_unique_counts[seqstr] = [seq.id for _ in range(int(seq.id))]
         else:

--- a/gctree/isotyping.py
+++ b/gctree/isotyping.py
@@ -52,11 +52,11 @@ class IsotypeTemplate:
         if weight_matrix is None:
             weight_matrix = [
                 [
-                    0.0
-                    if target == origin
-                    else 1.0
-                    if target > origin
-                    else float("inf")
+                    (
+                        0.0
+                        if target == origin
+                        else 1.0 if target > origin else float("inf")
+                    )
                     for target in range(n)
                 ]
                 for origin in range(n)

--- a/gctree/mutation_model.py
+++ b/gctree/mutation_model.py
@@ -235,9 +235,9 @@ class MutationModel:
                         + str(trials)
                         + " consecutive attempts"
                     )
-                sequence_list[
-                    mut_pos
-                ] = original_base  # <-- we only get here if we are retrying
+                sequence_list[mut_pos] = (
+                    original_base  # <-- we only get here if we are retrying
+                )
 
         return sequence
 

--- a/gctree/utils.py
+++ b/gctree/utils.py
@@ -1,4 +1,5 @@
 r"""Utility functions."""
+
 from functools import wraps, reduce
 import Bio.Data.IUPACData
 import operator


### PR DESCRIPTION
When there are very many MP trees, it's possible to get the following error during inference:
```
AttributeError: 'int' object has no attribute 'log'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wdumm/Downloads/gctree/gctree/branching_processes.py", line 1124, in mle
    self.parameters = _mle_helper(self.ll, **kwargs)
  File "/Users/wdumm/Downloads/gctree/gctree/branching_processes.py", line 1631, in _mle_helper
    grad_check = sco.check_grad(lambda x: f(x)[0], lambda x: f(x)[1], x_0)
  File "/Users/wdumm/Downloads/gctreetestenv/lib/python3.9/site-packages/scipy/optimize/_optimize.py", line 1178, in check_grad
    analytical_grad = grad(x0, *args)
  File "/Users/wdumm/Downloads/gctree/gctree/branching_processes.py", line 1631, in <lambda>
    grad_check = sco.check_grad(lambda x: f(x)[0], lambda x: f(x)[1], x_0)
  File "/Users/wdumm/Downloads/gctree/gctree/branching_processes.py", line 1629, in f
    return tuple(-y for y in ll(*x, **kwargs))
  File "/usr/local/Cellar/python@3.9/3.9.18_2/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/wdumm/Downloads/gctree/gctree/branching_processes.py", line 1104, in ll
    return (-np.log(count_ls.sum()) + scs.logsumexp(ls, b=count_ls)), np.array(
TypeError: loop of ufunc does not support argument 0 of type int which has no callable log method
```

This is because `numpy.log` doesn't work on integer arguments greater than 2**64. Luckily in this case we're always just calling log on an integer (not arrays) so the fix is simply to use `math.log`.