### PR TITLE
Handle truncated dnapars `outfile`s correctly

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,15 +19,12 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - name: Install Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: '1.5.6-0' # any version from https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
           init-shell: bash
-          cache-environment: false
+          cache-environment: true
           post-cleanup: 'none'
 
       - name: Test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,15 +22,13 @@ jobs:
       - name: Install Pandoc
         uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Install miniconda and create environment
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          activate-environment: gctree
+          micromamba-version: '1.5.6-0' # any version from https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge,defaults,bioconda
-          auto-activate-base: false
-          auto-update-conda: false
+          init-shell: bash
+          cache-environment: false
+          post-cleanup: 'none'
 
       - name: Test
         shell: bash -l {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install miniconda and create environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: gctree
           environment-file: environment.yml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: [3.7, 3.8, 3.9, "3.10"] # https://github.com/actions/runner/issues/1989
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,4 +32,5 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install .
+          pip install -r requirements.txt
           make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"] # https://github.com/actions/runner/issues/1989
-      exclude:
-        # excludes 3.7 on macos-latest (no native build for M1)
-        - os: macos-latest
-          python-version: 3.7
+        exclude:
+          # excludes 3.7 on macos-latest (no native build for M1)
+          - os: macos-latest
+            python-version: 3.7
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"] # https://github.com/actions/runner/issues/1989
+      exclude:
+        # excludes 3.7 on macos-latest (no native build for M1)
+        - os: macos-latest
+          python-version: 3.7
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,7 @@ jobs:
           activate-environment: gctree
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
+          channels: conda-forge,defaults,bioconda
           auto-activate-base: false
           auto-update-conda: true
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"] # https://github.com/actions/runner/issues/1989
 
     runs-on: ${{ matrix.os }}
@@ -19,14 +19,13 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - uses: mamba-org/setup-micromamba@v1
+      - name: Python Setup
+        uses: actions/setup-python@v5
         with:
-          micromamba-version: '1.5.6-0' # any version from https://github.com/mamba-org/micromamba-releases
-          environment-file: environment.yml
-          init-shell: bash
-          cache-environment: true
-          post-cleanup: 'none'
+          python-version: ${{ matrix.python-version }}
 
-      - name: Test
+      - name: Install and Test
         shell: bash -l {0}
-        run: make test
+        run: |
+          pip install .
+          make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge,defaults,bioconda
           auto-activate-base: false
-          auto-update-conda: true
+          auto-update-conda: false
 
       - name: Test
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 name: gctree
 channels:
-  - conda-forge
-  - defaults
   - bioconda
+  - defaults
 dependencies:
   - phylip
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: gctree
 channels:
+  - conda-forge
   - bioconda
   - defaults
 dependencies:

--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -673,7 +673,7 @@ class CollapsedTree:
         Returns:
             Dictionary of node names to hex color strings, which may be used as the colormap in :meth:`gctree.CollapsedTree.render`
         """
-        cmap = mp.cm.get_cmap(cmap)
+        cmap = mp.colormaps[cmap]
 
         if vmin is None:
             vmin = np.nanmin([getattr(node, feature) for node in self.tree.traverse()])

--- a/gctree/phylip_parse.py
+++ b/gctree/phylip_parse.py
@@ -16,8 +16,10 @@ import argparse
 from warnings import warn
 from typing import Dict
 
+
 class TreeParseError(RuntimeError):
     pass
+
 
 code_vectors = {
     code: [
@@ -108,6 +110,7 @@ def get_expected_trees(outfile):
         else:
             return None
 
+
 # parse the dnaml output file and return data structures containing a
 # list biopython.SeqRecords and a dict containing adjacency
 # relationships and distances between nodes.
@@ -165,17 +168,27 @@ def parse_outfile(outfile, abundance_file=None, root="root", disambiguate=False)
                     bootstrap = True
                     trees.append([])
                 else:
-                    raise TreeParseError("unrecognized phylip section = {}".format(sect))
+                    raise TreeParseError(
+                        "unrecognized phylip section = {}".format(sect)
+                    )
             except TreeParseError:
                 if _expected_n_trees is not None:
                     expected_message = f" but {_expected_n_trees} were expected"
                 else:
                     expected_message = ""
-                warn(f"Error parsing {outfile}! {len(trees)} successfully read{expected_message}.")
+                warn(
+                    f"Error parsing {outfile}! {len(trees)} successfully read{expected_message}."
+                )
                 _n_trees_warned = True
                 break
-        if not _n_trees_warned and _expected_n_trees is not None and _expected_n_trees != len(trees):
-            warn(f"Parsed {len(trees)} from {outfile} but {_expected_n_trees} expected!")
+        if (
+            not _n_trees_warned
+            and _expected_n_trees is not None
+            and _expected_n_trees != len(trees)
+        ):
+            warn(
+                f"Parsed {len(trees)} from {outfile} but {_expected_n_trees} expected!"
+            )
     if len(trees) == 0:
         raise RuntimeError(f"No trees found in '{outfile}'")
     if disambiguate:

--- a/tests/example_output/observed_root/small_outfile
+++ b/tests/example_output/observed_root/small_outfile
@@ -2,7 +2,7 @@
 DNA parsimony algorithm, version 3.697
 
 
-   540 trees in all found
+   20 trees in all found
 
 
   +seq41     

--- a/tests/example_output/original/small_outfile
+++ b/tests/example_output/original/small_outfile
@@ -2,7 +2,7 @@
 DNA parsimony algorithm, version 3.697
 
 
-   263 trees in all found
+   20 trees in all found
 
 
   +seq3      

--- a/tests/small_outfile
+++ b/tests/small_outfile
@@ -2,7 +2,7 @@
 DNA parsimony algorithm, version 3.697
 
 
-   263 trees in all found
+   20 trees in all found
 
 
   +seq3      


### PR DESCRIPTION
This PR intends to solve #113, which Duncan also has had to deal with a bit lately. Sometimes when dnapars finds thousands of trees, it just stops writing the outfile randomly, and although gctree will usually parse the outfile, the last tree is badly formed in a way that causes a confusing error later on in the inference process.

* Adds a `TreeParseError` class in `phylip_parse.py`
* Adds checks in `parse_outfile` that
    * all parsed node sequences have the same length. This handles the situation where truncation occurs in the middle of a line of the sequences section of the outfile.
    * all parsed node sequences' lengths match the sequence lengths of the first parsed tree. This handles the situation where truncation occurs between two phylip-format blocks in the sequence section of the outfile, in which case the parsed sequences will be incorrect, but all of the same length. Obviously this doesn't handle the case where truncation occurs in the first tree, but that seems very unlikely.
    * the number of parsed trees matches the number reported to have been discovered by dnapars at the beginning of the outfile. If they do not match, we throw a warning but continue.
* If parsing of a tree fails for any of the reasons above, `parse_outfile` does not attempt to parse any more trees from the outfile, and returns only the successfully parsed trees, but will always throw a warning if this happens.


These checks should be low-cost, but not totally free. Once per parsed tree, we iterate through the parsed sequence dictionary and accumulate the lengths as a set. Since this set should only have one element, this is about the same as checking that each sequence length is equal to the first. There are slightly faster ways of checking, but I don't think this should be a significant cost.

I tested these changes on a variety of truncated outfiles. I'm not certain they'll handle every case, but I think they should handle any case that I've seen happen. I didn't think it was necessary to commit additional tests, since this is handling a rare edge case.


## Changes to CI tests:
It seems that the CI runner `macos-latest` has recently become Apple Silicon by default, and the phylip package on Bioconda is not available for that architecture. To run tests we don't need phylip, and that was the only reason we were running tests in a Conda environment at all, so I switched to a Pip install, and skip installing phylip altogether.


