### PR TITLE
131 Fix rendering hang when parent directory of output file doesn't exist

### DIFF
--- a/gctree/branching_processes.py
+++ b/gctree/branching_processes.py
@@ -18,7 +18,6 @@ import seaborn as sns
 import numpy as np
 import warnings
 import random
-import os
 import scipy.special as scs
 import scipy.optimize as sco
 import ete3
@@ -36,6 +35,7 @@ import matplotlib.pyplot as plt
 from typing import Tuple, Dict, List, Union, Set, Callable, Mapping, Sequence, Optional
 from decimal import Decimal
 import math
+from pathlib import Path
 
 sequence_resolutions = hdag.parsimony_utils.standard_nt_ambiguity_map_gap_as_char.get_sequence_resolution_func(
     "sequence"
@@ -485,6 +485,10 @@ class CollapsedTree:
             show_nuc_muts: If True, annotate branches with nucleotide mutations. If False, and frame is provided, then branches
                 will be annotated with amino acid mutations.
         """
+        # Create parent directories of outfile if they don't exist
+        outfile = Path(outfile)
+        outfile.parent.mkdir(parents=True, exist_ok=True)
+
         if frame is not None and frame not in (1, 2, 3):
             raise RuntimeError("frame must be 1, 2, or 3")
 
@@ -675,10 +679,10 @@ class CollapsedTree:
                         description=f"abundance={node.abundance}",
                     )
                 )
-            AlignIO.write(
-                aln, open(os.path.splitext(outfile)[0] + ".fasta", "w"), "fasta"
-            )
-        return tree_copy.render(outfile, tree_style=ts)
+            with open(outfile.with_suffix(".fasta"), "w") as fh:
+                AlignIO.write(aln, fh, "fasta")
+
+        return tree_copy.render(str(outfile), tree_style=ts)
 
     def feature_colormap(
         self,

--- a/gctree/cli.py
+++ b/gctree/cli.py
@@ -15,6 +15,7 @@ import pickle
 import random
 import ete3
 import itertools
+from pathlib import Path
 
 
 def test(args):
@@ -163,6 +164,9 @@ def infer(args):
             idmap_file=args.idmapfile,
             isotype_names=args.isotype_names,
         )
+
+    # Make parent directory of output file base string if it doesn't exist
+    Path(args.outbase).parent.mkdir(parents=True, exist_ok=True)
 
     if len(args.infiles) == 2:
         forest = bp.CollapsedForest(

--- a/tests/smalltest.sh
+++ b/tests/smalltest.sh
@@ -14,7 +14,7 @@ wget -O $substitutions https://bitbucket.org/kleinstein/shazam/raw/ba4b30fc6791e
 
 # testing backward compatibility:
 
-gctree infer tests/small_outfile tests/abundances.csv --outbase tests/smalltest_output/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 1 0 --use_old_mut_parsimony --branching_process_ranking_coeff 0 
+gctree infer tests/small_outfile tests/abundances.csv --outbase tests/smalltest_output/nonexistant_dir/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 1 0 --use_old_mut_parsimony --branching_process_ranking_coeff 0 
 
 gctree infer tests/smalltest_output/gctree.infer.inference.parsimony_forest.p --outbase tests/smalltest_output/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 -1 0 --use_old_mut_parsimony
 

--- a/tests/smalltest.sh
+++ b/tests/smalltest.sh
@@ -14,9 +14,9 @@ wget -O $substitutions https://bitbucket.org/kleinstein/shazam/raw/ba4b30fc6791e
 
 # testing backward compatibility:
 
-gctree infer tests/small_outfile tests/abundances.csv --outbase tests/smalltest_output/nonexistant_dir/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 1 0 --use_old_mut_parsimony --branching_process_ranking_coeff 0 
+gctree infer tests/small_outfile tests/abundances.csv --outbase tests/smalltest_output/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 1 0 --use_old_mut_parsimony --branching_process_ranking_coeff 0 
 
-gctree infer tests/smalltest_output/gctree.infer.inference.parsimony_forest.p --outbase tests/smalltest_output/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 -1 0 --use_old_mut_parsimony
+gctree infer tests/smalltest_output/gctree.infer.inference.parsimony_forest.p --outbase tests/smalltest_output/nonexistant_dir/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --ranking_coeffs 1 -1 0 --use_old_mut_parsimony
 
 gctree infer tests/small_outfile tests/abundances.csv --outbase tests/smalltest_output/gctree.infer --root GL --frame 1 --verbose --idlabel --idmapfile tests/idmap.txt --isotype_mapfile tests/isotypemap.txt --mutability HS5F_Mutability.csv --substitution HS5F_Substitution.csv --use_old_mut_parsimony
 


### PR DESCRIPTION
This PR should fix #131 by creating parent directories as necessary before attempting to render to the provided filename. It also replaces `os` file handling with `pathlib.Path` in `branching_processes.py`.